### PR TITLE
Custom naming for serverless-step-functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,26 @@ plugins:
   - serverless-step-functions
 ```
 
+### Adding a custom name for a stateMachine
+In case you need to interpolate a specific stage or service layer variable as the
+stateMachines name you can add a `Name` property to your yaml.
+
+```yml
+service: messager
+
+functions:
+  sendMessage:
+    handler: handler.sendMessage
+
+stepFunctions:
+  stateMachines:
+    sendMessageFunc:
+      Name: sendMessageFunc-${self:custom.service}-${opt:stage}
+      definition:
+        <your definition>
+
+plugins:
+  - serverless-step-functions
+```
+
+Please note, that during normalization some characters will be changed to adhere to CloudFormation templates.

--- a/lib/deploy/stepFunctions/compileStateMachines.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.js
@@ -10,6 +10,11 @@ module.exports = {
         let DefinitionString;
         let RoleArn;
         let DependsOn;
+        let Name;
+
+        if( stateMachineObj.Name ) {
+          Name = stateMachineObj.Name;
+        }
 
         if (stateMachineObj.definition) {
           DefinitionString = JSON.stringify(stateMachineObj.definition);
@@ -47,8 +52,8 @@ module.exports = {
           DependsOn = 'IamRoleStateMachineExecution';
         }
 
-        const stateMachineLogicalId = this.getStateMachineLogicalId(stateMachineName);
-        const stateMachineOutputLogicalId = this.getStateMachineOutputLogicalId(stateMachineName);
+        const stateMachineLogicalId = this.getStateMachineLogicalId(stateMachineName, Name);
+        const stateMachineOutputLogicalId = this.getStateMachineOutputLogicalId(stateMachineName, Name);
 
         const stateMachineTemplate = `
           {
@@ -83,6 +88,7 @@ module.exports = {
         _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs,
           newStateMachineOutPutObject
         );
+
         return BbPromise.resolve();
       });
     }

--- a/lib/deploy/stepFunctions/compileStateMachines.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.js
@@ -12,7 +12,7 @@ module.exports = {
         let DependsOn;
         let Name;
 
-        if( stateMachineObj.Name ) {
+        if (stateMachineObj.Name) {
           Name = stateMachineObj.Name;
         }
 
@@ -53,7 +53,8 @@ module.exports = {
         }
 
         const stateMachineLogicalId = this.getStateMachineLogicalId(stateMachineName, Name);
-        const stateMachineOutputLogicalId = this.getStateMachineOutputLogicalId(stateMachineName, Name);
+        const stateMachineOutputLogicalId = this
+                        .getStateMachineOutputLogicalId(stateMachineName, Name);
 
         const stateMachineTemplate = `
           {

--- a/lib/deploy/stepFunctions/compileStateMachines.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.js
@@ -12,7 +12,7 @@ module.exports = {
         let DependsOn;
         let Name;
 
-        if (stateMachineObj.Name) {
+        if (stateMachineObj.hasOwnProperty('Name')) {
           Name = stateMachineObj.Name;
         }
 

--- a/lib/deploy/stepFunctions/compileStateMachines.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.js
@@ -12,7 +12,7 @@ module.exports = {
         let DependsOn;
         let Name;
 
-        if (stateMachineObj.hasOwnProperty('Name')) {
+        if (stateMachineObj.Name) {
           Name = stateMachineObj.Name;
         }
 

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -76,6 +76,55 @@ describe('#compileStateMachines', () => {
     ).to.equal('MyStateMachine2StepFunctionsStateMachine');
   });
 
+  it('should create named resources when Name is provided', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          definition: 'definition1',
+          Name: 'stateMachineBeta1',
+        },
+        myStateMachine2: {
+          definition: 'definition2',
+          Name: 'stateMachineBeta2',
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileStateMachines();
+    expect(serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .StateMachineBeta1.Type
+    ).to.equal('AWS::StepFunctions::StateMachine');
+    expect(serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .StateMachineBeta2.Type
+    ).to.equal('AWS::StepFunctions::StateMachine');
+    expect(serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .StateMachineBeta1.Properties.DefinitionString
+    ).to.equal('"definition1"');
+    expect(serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .StateMachineBeta2.Properties.DefinitionString
+    ).to.equal('"definition2"');
+    expect(serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .StateMachineBeta1.Properties.RoleArn['Fn::GetAtt'][0]
+    ).to.equal('IamRoleStateMachineExecution');
+    expect(serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .StateMachineBeta2.Properties.RoleArn['Fn::GetAtt'][0]
+    ).to.equal('IamRoleStateMachineExecution');
+    expect(serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .StateMachineBeta1.DependsOn
+    ).to.equal('IamRoleStateMachineExecution');
+    expect(serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .StateMachineBeta2.DependsOn
+    ).to.equal('IamRoleStateMachineExecution');
+  });
+
   it('should create corresponding resources when definition and role property are given', () => {
     serverless.service.stepFunctions = {
       stateMachines: {

--- a/lib/naming.js
+++ b/lib/naming.js
@@ -1,12 +1,18 @@
 'use strict';
 
 module.exports = {
-  getStateMachineLogicalId(stateMachineName) {
+  getStateMachineLogicalId(stateMachineName, Name) {
+    if( Name ) {
+      return Name;
+    }
     return `${this.provider.naming
       .getNormalizedFunctionName(stateMachineName)}StepFunctionsStateMachine`;
   },
 
-  getStateMachineOutputLogicalId(stateMachineName) {
+  getStateMachineOutputLogicalId(stateMachineName, Name) {
+    if( Name ) {
+      return Name;
+    }
     return `${this.provider.naming
       .getNormalizedFunctionName(stateMachineName)}StepFunctionsStateMachineArn`;
   },

--- a/lib/naming.js
+++ b/lib/naming.js
@@ -3,7 +3,7 @@
 module.exports = {
   getStateMachineLogicalId(stateMachineName, Name) {
     if( Name ) {
-      return Name;
+      return `${this.provider.naming.getNormalizedFunctionName(Name)}`
     }
     return `${this.provider.naming
       .getNormalizedFunctionName(stateMachineName)}StepFunctionsStateMachine`;
@@ -11,7 +11,7 @@ module.exports = {
 
   getStateMachineOutputLogicalId(stateMachineName, Name) {
     if( Name ) {
-      return Name;
+      return `${this.provider.naming.getNormalizedFunctionName(Name)}`
     }
     return `${this.provider.naming
       .getNormalizedFunctionName(stateMachineName)}StepFunctionsStateMachineArn`;

--- a/lib/naming.js
+++ b/lib/naming.js
@@ -2,16 +2,16 @@
 
 module.exports = {
   getStateMachineLogicalId(stateMachineName, Name) {
-    if( Name ) {
-      return `${this.provider.naming.getNormalizedFunctionName(Name)}`
+    if (Name) {
+      return `${this.provider.naming.getNormalizedFunctionName(Name)}`;
     }
     return `${this.provider.naming
       .getNormalizedFunctionName(stateMachineName)}StepFunctionsStateMachine`;
   },
 
   getStateMachineOutputLogicalId(stateMachineName, Name) {
-    if( Name ) {
-      return `${this.provider.naming.getNormalizedFunctionName(Name)}`
+    if (Name) {
+      return `${this.provider.naming.getNormalizedFunctionName(Name)}`;
     }
     return `${this.provider.naming
       .getNormalizedFunctionName(stateMachineName)}StepFunctionsStateMachineArn`;

--- a/lib/naming.js
+++ b/lib/naming.js
@@ -11,7 +11,7 @@ module.exports = {
 
   getStateMachineOutputLogicalId(stateMachineName, Name) {
     if (Name) {
-      return `${this.provider.naming.getNormalizedFunctionName(Name)}`;
+      return `${this.provider.naming.getNormalizedFunctionName(Name)}Arn`;
     }
     return `${this.provider.naming
       .getNormalizedFunctionName(stateMachineName)}StepFunctionsStateMachineArn`;

--- a/lib/naming.test.js
+++ b/lib/naming.test.js
@@ -32,6 +32,20 @@ describe('#naming', () => {
     });
   });
 
+  describe('#getStateMachineLogicalId() -- Named', () => {
+    it('should normalize the stateMachine name and add the standard suffix', () => {
+      expect(serverlessStepFunctions.getStateMachineLogicalId('stateMachine', 'alphaNumeric')).to
+      .equal('AlphaNumeric');
+    });
+  });
+
+  describe('#getStateMachineOutputLogicalId() -- Named', () => {
+    it('should normalize the stateMachine output name and add the standard suffix', () => {
+      expect(serverlessStepFunctions.getStateMachineOutputLogicalId('stateMachine', 'alphaNumeric'))
+      .to.equal('AlphaNumericArn');
+    });
+  });
+
   describe('#getActivityLogicalId()', () => {
     it('should normalize the activity name and add the standard suffix', () => {
       expect(serverlessStepFunctions.getActivityLogicalId('activity')).to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-step-functions",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "The module is AWS Step Functions plugin for Serverless Framework",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Allow users to provide their own stepMachine naming convention.

_example_ 
```
functions:
  hello:
    handler: handler.hello

stepFunctions:
  stateMachines:
    hellostepfunc:
      Name: hellostepfunc-${opt:stage}
      definition:
        <your definition>

plugins:
  - serverless-step-functions
```