### PR TITLE
Not indenting path and method results in error

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ stepFunctions:
     hellostepfunc1:
       events:
         - http:
-          path: gofunction
-          method: GET
+            path: gofunction
+            method: GET
       name: myStateMachine
       definition:
         Comment: "A Hello World example of the Amazon States Language using an AWS Lambda Function"


### PR DESCRIPTION
If you copy the formatting of the README it results in an error `Cannot read property 'path' of null`. This fixed it for me.