### PR TITLE
State machine definition validation using asl-validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,16 @@ $ sls invoke stepf --name <stepfunctionname> --data '{"foo":"bar"}'
 - --data or -d String data to be passed as an event to your step function.
 - --path or -p The path to a json file with input data to be passed to the invoked step function.
 
+### validate-state-machines
+This command allows you to validate the definition of your state machine(s). Validation is done by [asl-validator](https://www.npmjs.com/package/asl-validator).
+```
+$ sls validate-state-machines [--name <stepfunctionname>]
+```
+
+#### options
+
+- --name or -n The name of the step function in your service that you want to validate. Will validate all state machines if not specified.
+
 ## IAM Role
 The IAM roles required to run Statemachine are automatically generated. It is also possible to specify ARN directly.
 

--- a/README.md
+++ b/README.md
@@ -260,10 +260,10 @@ $ sls invoke stepf --name <stepfunctionname> --data '{"foo":"bar"}'
 - --data or -d String data to be passed as an event to your step function.
 - --path or -p The path to a json file with input data to be passed to the invoked step function.
 
-### validate-state-machines
+### validate
 This command allows you to validate the definition of your state machine(s). Validation is done by [asl-validator](https://www.npmjs.com/package/asl-validator).
 ```
-$ sls validate-state-machines [--name <stepfunctionname>]
+$ sls validate stepf [--name <stepfunctionname>]
 ```
 
 #### options

--- a/lib/index.js
+++ b/lib/index.js
@@ -163,13 +163,13 @@ class ServerlessStepFunctions {
     let resolve = true;
     for (const stateMachineName of stateMachines) {
       const definition = this.getStateMachine(stateMachineName).definition;
-      const { isValid, errors } = aslValidator(definition);
-      if (isValid) {
+      const result = aslValidator(definition);
+      if (result.isValid) {
         this.serverless.cli.consoleLog(`✓ ${stateMachineName} definition is valid`);
       } else {
         const errorMessage = [
           `✕ ${stateMachineName} definition is invalid:\n`,
-          JSON.stringify(errors),
+          JSON.stringify(result.errors),
         ];
         this.serverless.cli.consoleLog(errorMessage);
         resolve = false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,15 +82,19 @@ class ServerlessStepFunctions {
           },
         },
       },
-      'validate-state-machines': {
-        usage: 'Validate state machine definitions',
-        lifecycleEvents: [
-          'validate',
-        ],
-        options: {
-          name: {
-            usage: 'The StateMachine name (validate all state machines if not specified)',
-            shortcut: 'n',
+      validate: {
+        commands: {
+          stepf: {
+            usage: 'Validate step function state machine definitions',
+            lifecycleEvents: [
+              'validate',
+            ],
+            options: {
+              name: {
+                usage: 'The StateMachine name (validate all state machines if not specified)',
+                shortcut: 'n',
+              },
+            },
           },
         },
       },
@@ -100,9 +104,9 @@ class ServerlessStepFunctions {
       'invoke:stepf:invoke': () => BbPromise.bind(this)
         .then(this.yamlParse)
         .then(this.invoke),
-      'validate-state-machines:validate': () => BbPromise.bind(this)
+      'validate:stepf:validate': () => BbPromise.bind(this)
         .then(this.yamlParse)
-        .then(this.validateStateMachines),
+        .then(this.validate),
       'package:initialize': () => BbPromise.bind(this)
         .then(this.yamlParse),
       'package:compileFunctions': () => BbPromise.bind(this)
@@ -152,7 +156,7 @@ class ServerlessStepFunctions {
     });
   }
 
-  validateStateMachines() {
+  validate() {
     this.serverless.cli.consoleLog('Validating state machines definition...');
     const stateMachines = (this.options.name && [this.options.name]) ||
       Object.keys(this.serverless.service.stepFunctions.stateMachines);

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ const yamlParser = require('./yamlParser');
 const naming = require('./naming');
 const _ = require('lodash');
 const chalk = require('chalk');
+const aslValidator = require('asl-validator');
 
 class ServerlessStepFunctions {
   constructor(serverless, options) {
@@ -81,12 +82,27 @@ class ServerlessStepFunctions {
           },
         },
       },
+      'validate-state-machines': {
+        usage: 'Validate state machine definitions',
+        lifecycleEvents: [
+          'validate',
+        ],
+        options: {
+          name: {
+            usage: 'The StateMachine name (validate all state machines if not specified)',
+            shortcut: 'n',
+          },
+        },
+      },
     };
 
     this.hooks = {
       'invoke:stepf:invoke': () => BbPromise.bind(this)
         .then(this.yamlParse)
         .then(this.invoke),
+      'validate-state-machines:validate': () => BbPromise.bind(this)
+        .then(this.yamlParse)
+        .then(this.validateStateMachines),
       'package:initialize': () => BbPromise.bind(this)
         .then(this.yamlParse),
       'package:compileFunctions': () => BbPromise.bind(this)
@@ -134,6 +150,32 @@ class ServerlessStepFunctions {
       this.serverless.cli.consoleLog(result);
       return BbPromise.resolve();
     });
+  }
+
+  validateStateMachines() {
+    this.serverless.cli.consoleLog('Validating state machines definition...');
+    const stateMachines = (this.options.name && [this.options.name]) ||
+      Object.keys(this.serverless.service.stepFunctions.stateMachines);
+    let resolve = true;
+    for (const stateMachineName of stateMachines) {
+      const definition = this.getStateMachine(stateMachineName).definition;
+      const { isValid, errors } = aslValidator(definition);
+      if (isValid) {
+        this.serverless.cli.consoleLog(`✓ ${stateMachineName} definition is valid`);
+      } else {
+        const errorMessage = [
+          `✕ ${stateMachineName} definition is invalid:\n`,
+          JSON.stringify(errors),
+        ];
+        this.serverless.cli.consoleLog(errorMessage);
+        resolve = false;
+      }
+    }
+    if (resolve) {
+      return BbPromise.resolve();
+    }
+    throw new this.serverless.classes
+      .Error('At least one of your state machine definition is invalid.');
   }
 
   display() {

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -368,4 +368,72 @@ describe('#index', () => {
       expect(message).to.equal(expectedMessage);
     });
   });
+
+  describe('#validateStateMachines()', () => {
+    let consoleLogStub;
+
+    beforeEach(() => {
+      consoleLogStub = sinon.stub(serverless.cli, 'consoleLog').returns();
+    });
+
+    afterEach(() => {
+      serverlessStepFunctions.serverless.cli.consoleLog.restore();
+    });
+
+    it('should validate state machine as definition is valid', () => {
+      serverlessStepFunctions.serverless.service.stepFunctions = {
+        stateMachines: {
+          myStateMachine: {
+            definition: { // Valid definition
+              StartAt: 'HelloWorld',
+              States: {
+                HelloWorld: {
+                  Type: 'Pass',
+                  Result: 'Hello World!',
+                  End: true,
+                },
+              },
+            },
+          },
+        },
+      };
+      serverlessStepFunctions.validateStateMachines();
+      // would have thrown if definition was invalid
+      expect(consoleLogStub.calledTwice).to.equal(true);
+    });
+
+    it('should throw as state machine as definition is invalid', () => {
+      const expectedErrorMessage = 'At least one of your state machine definition is invalid.';
+      serverlessStepFunctions.serverless.service.stepFunctions = {
+        stateMachines: {
+          myStateMachine: {
+            definition: { // Missing Next or End property
+              StartAt: 'HelloWorld',
+              States: {
+                HelloWorld: {
+                  Type: 'Pass',
+                  Result: 'Hello World!',
+                },
+              },
+            },
+          },
+        },
+      };
+      expect(() => serverlessStepFunctions.validateStateMachines())
+        .to.throw(serverlessStepFunctions.serverless.classes.Error, expectedErrorMessage);
+      expect(consoleLogStub.calledTwice).to.equal(true);
+    });
+
+    it('should throw as step function name does not exist', () => {
+      const inexistant = 'inexistantStateMachine';
+      const expectedErrorMessage = `stateMachine "${inexistant}" doesn't exist in this Service`;
+      serverlessStepFunctions.options.name = inexistant;
+      serverlessStepFunctions.serverless.service.stepFunctions = {
+        stateMachines: {},
+      };
+      expect(() => serverlessStepFunctions.validateStateMachines())
+        .to.throw(serverlessStepFunctions.serverless.classes.Error, expectedErrorMessage);
+      expect(consoleLogStub.calledOnce).to.equal(true);
+    });
+  });
 });

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -369,7 +369,7 @@ describe('#index', () => {
     });
   });
 
-  describe('#validateStateMachines()', () => {
+  describe('#validate()', () => {
     let consoleLogStub;
 
     beforeEach(() => {
@@ -397,7 +397,7 @@ describe('#index', () => {
           },
         },
       };
-      serverlessStepFunctions.validateStateMachines();
+      serverlessStepFunctions.validate();
       // would have thrown if definition was invalid
       expect(consoleLogStub.calledTwice).to.equal(true);
     });
@@ -419,7 +419,7 @@ describe('#index', () => {
           },
         },
       };
-      expect(() => serverlessStepFunctions.validateStateMachines())
+      expect(() => serverlessStepFunctions.validate())
         .to.throw(serverlessStepFunctions.serverless.classes.Error, expectedErrorMessage);
       expect(consoleLogStub.calledTwice).to.equal(true);
     });
@@ -431,7 +431,7 @@ describe('#index', () => {
       serverlessStepFunctions.serverless.service.stepFunctions = {
         stateMachines: {},
       };
-      expect(() => serverlessStepFunctions.validateStateMachines())
+      expect(() => serverlessStepFunctions.validate())
         .to.throw(serverlessStepFunctions.serverless.classes.Error, expectedErrorMessage);
       expect(consoleLogStub.calledOnce).to.equal(true);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,9 +199,9 @@
       "dev": true
     },
     "asl-validator": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-1.0.4.tgz",
-      "integrity": "sha512-eGDyq/rVdMHdbsrUnf4SFobD+zxuv2xr6YQt9umk5lAL/0rGzoZU1ESyfszs7FDnueGRaIojwH0gygEHhpNzpw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-1.0.5.tgz",
+      "integrity": "sha1-Ke+VIvtwirTBzpodLiR4/fb+2Cg=",
       "requires": {
         "ajv": "5.5.1",
         "commander": "2.12.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-step-functions",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -197,6 +197,33 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
+    },
+    "asl-validator": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-1.0.4.tgz",
+      "integrity": "sha512-eGDyq/rVdMHdbsrUnf4SFobD+zxuv2xr6YQt9umk5lAL/0rGzoZU1ESyfszs7FDnueGRaIojwH0gygEHhpNzpw==",
+      "requires": {
+        "ajv": "5.5.1",
+        "commander": "2.12.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+          "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+        }
+      }
     },
     "asn1": {
       "version": "0.2.3",
@@ -477,8 +504,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1244,6 +1270,16 @@
       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
       "dev": true
     },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -1986,6 +2022,11 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
     "sinon": "^1.17.5"
   },
   "dependencies": {
-    "lodash": "^4.13.1",
+    "asl-validator": "^1.0.4",
     "aws-sdk": "^2.7.19",
     "bluebird": "^3.4.0",
-    "chalk": "^1.1.1"
+    "chalk": "^1.1.1",
+    "lodash": "^4.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sinon": "^1.17.5"
   },
   "dependencies": {
-    "asl-validator": "^1.0.4",
+    "asl-validator": "^1.0.5",
     "aws-sdk": "^2.7.19",
     "bluebird": "^3.4.0",
     "chalk": "^1.1.1",


### PR DESCRIPTION
Hi !

I have added a validation command for the state machine definition. All the logic is handled in [asl-validator](https://www.npmjs.com/package/asl-validator) package.

It can help saving a lot of time avoiding failed deployment because of a wrong state machine definition,

You can use it like this: `sls validate-state-machines [--name <stepfunctionname>]`.

I also plan to add it in the `deploy` command, but I'd like it to happen at the beginning (before packaging everything). Let me know what you think about it, and if you have some thoughts about when exactly running validation.

Some output examples:
## Valid definition
```
$ serverless validate-state-machine -vServerless: Validating state machines definition
Serverless: ✓ yourParallelMachine definition is valid
```

## State machine does not exists
```
$ serverless validate-state-machine -n yourParallelMachines
Serverless: Validating state machines definition
 
  Serverless Error ---------------------------------------
 
  stateMachine "yourParallelMachines" doesn't exist in this Service
```

## Invalid defintion (missing StartAt property)
```
$ serverless validate-state-machine
Serverless: Validating state machines definition
Serverless: ✕ yourParallelMachine definition is invalid:
[{"keyword":"required","dataPath":"","schemaPath":"#/required","params":{"missingProperty":"StartAt"},"message":"should have required property 'StartAt'"}]
 
  Serverless Error ---------------------------------------
 
  At least one of your state machine definition is invalid.
```