### PR TITLE
Improve branch code coverage

### DIFF
--- a/lib/yamlParser.test.js
+++ b/lib/yamlParser.test.js
@@ -35,6 +35,40 @@ describe('#yamlParse', () => {
       serverlessStepFunctions.serverless.config.servicePath = 'servicePath';
     });
 
+    it('should default to dev when stage and provider are not defined', () => {
+      serverlessStepFunctions.serverless.pluginManager.cliOptions.stage = null;
+      serverlessStepFunctions.serverless.service.provider = null;
+      serverlessStepFunctions.yamlParse()
+      .then(() => {
+        expect(serverless.pluginManager.cliOptions.stage).to.be.equal('dev');
+      });
+    });
+
+    it('should default to us-east-1 when region and provider are not defined', () => {
+      serverlessStepFunctions.serverless.pluginManager.cliOptions.region = null;
+      serverlessStepFunctions.serverless.service.provider = null;
+      serverlessStepFunctions.yamlParse()
+      .then(() => {
+        expect(serverless.pluginManager.cliOptions.region).to.be.equal('us-east-1');
+      });
+    });
+
+    it('should not default to dev when stage is defined', () => {
+      serverlessStepFunctions.serverless.pluginManager.cliOptions.stage = 'my-stage';
+      serverlessStepFunctions.yamlParse()
+      .then(() => {
+        expect(serverless.pluginManager.cliOptions.stage).to.be.equal('my-stage');
+      });
+    });
+
+    it('should not default to us-east-1 when region is defined', () => {
+      serverlessStepFunctions.serverless.pluginManager.cliOptions.region = 'my-region';
+      serverlessStepFunctions.yamlParse()
+      .then(() => {
+        expect(serverless.pluginManager.cliOptions.region).to.be.equal('my-region');
+      });
+    });
+
     it('should throw error if servicePath is not given', () => {
       serverlessStepFunctions.serverless.config.servicePath = null;
       serverlessStepFunctions.yamlParse()


### PR DESCRIPTION
I'm studying AWS Step Functions and found this plugin. When I executed $ npm test I realized there was a missing branch test.

Basically I included happy-case tests to make instanbul happy

```js
=============================== Coverage summary ===============================
Statements   : 100% ( 469/469 )
Branches     : 100% ( 200/200 )
Functions    : 100% ( 51/51 )
Lines        : 100% ( 466/466 )
```