### PR TITLE
Added handling of 'private' param to http events.

### DIFF
--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -18,6 +18,7 @@ module.exports = {
           HttpMethod: event.http.method.toUpperCase(),
           RequestParameters: {},
           AuthorizationType: 'NONE',
+          ApiKeyRequired: Boolean(event.http.private),
           ResourceId: resourceId,
           RestApiId: { Ref: this.apiGatewayRestApiLogicalId },
         },

--- a/lib/deploy/events/apiGateway/methods.test.js
+++ b/lib/deploy/events/apiGateway/methods.test.js
@@ -28,15 +28,25 @@ describe('#methods()', () => {
     };
     serverlessStepFunctions.apiGatewayResourceLogicalIds
       = { 'foo/bar': 'apiGatewayResourceLogicalId' };
-    serverlessStepFunctions.apiGatewayResourceNames
-      = { 'foo/bar': 'apiGatewayResourceNames' };
+    serverlessStepFunctions.apiGatewayResourceNames = {
+      'foo/bar1': 'apiGatewayResourceNamesFirst',
+      'foo/bar2': 'apiGatewayResourceNamesSecond',
+    };
     serverlessStepFunctions.pluginhttpValidated = {
       events: [
         {
           stateMachineName: 'first',
           http: {
-            path: 'foo/bar',
+            path: 'foo/bar1',
             method: 'post',
+          },
+        },
+        {
+          stateMachineName: 'first',
+          http: {
+            path: 'foo/bar2',
+            method: 'post',
+            private: true,
           },
         },
       ],
@@ -48,8 +58,21 @@ describe('#methods()', () => {
       .compileMethods().then(() => {
         expect(serverlessStepFunctions.serverless.service.provider.compiledCloudFormationTemplate
           .Resources)
-        .to.have.property('ApiGatewayMethodapiGatewayResourceNamesPost');
+          .to.have.property('ApiGatewayMethodapiGatewayResourceNamesFirstPost');
       })
+    );
+
+    it('should verify if http private parameter is correctly passed to resource',
+      () => serverlessStepFunctions
+        .compileMethods().then(() => {
+          const resources = serverlessStepFunctions
+            .serverless.service.provider.compiledCloudFormationTemplate.Resources;
+
+          expect(resources.ApiGatewayMethodapiGatewayResourceNamesFirstPost
+            .Properties.ApiKeyRequired).to.eql(false);
+          expect(resources.ApiGatewayMethodapiGatewayResourceNamesSecondPost
+            .Properties.ApiKeyRequired).to.eql(true);
+        })
     );
   });
 


### PR DESCRIPTION
### Description
Adding `private:true` to state machine events
```
"events": [
      {
        "http": {
          "path": "delijn/bookings/callback",
          "method": "post",
          "private": true
        }
      }
    ]
```

Should set `ApiKeyRequired: true` in `AWS::ApiGateway::Method` template.
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-setup-api-key-with-restapi.html

Without this parameter x-api-keys are ignored.

### Fix description
`private:true` is now handled and used in `AWS::ApiGateway::Method`.

