### PR TITLE
Do not display endpoints if there are none

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -138,10 +138,12 @@ class ServerlessStepFunctions {
 
   display() {
     let message = '';
+    let stateMachineMessages = '';
 
     const endpointInfo = this.endpointInfo;
     message += `${chalk.yellow.underline('Serverless StepFunctions OutPuts')}\n`;
     message += `${chalk.yellow('endpoints:')}`;
+
     if (this.isStateMachines()) {
       _.forEach(this.getAllStateMachines(), (stateMachineName) => {
         const stateMachineObj = this.getStateMachine(stateMachineName);
@@ -159,14 +161,22 @@ class ServerlessStepFunctions {
                 path = event.http.split(' ')[1];
               }
               path = path !== '/' ? `/${path.split('/').filter(p => p !== '').join('/')}` : '';
-              message += `\n  ${method} - ${endpointInfo}${path}`;
+              stateMachineMessages += `\n  ${method} - ${endpointInfo}${path}`;
             }
           });
         }
       });
     }
+
+    if (stateMachineMessages === '') {
+      return '';
+    }
+
+    message += stateMachineMessages;
     message += '\n';
+
     this.serverless.cli.consoleLog(message);
+
     return message;
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,7 +168,7 @@ class ServerlessStepFunctions {
       });
     }
 
-    if (stateMachineMessages === '') {
+    if (_.isEmpty(stateMachineMessages)) {
       return '';
     }
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -247,12 +247,9 @@ describe('#index', () => {
 
     it('should not display endpoints if http event not given', () => {
       serverlessStepFunctions.serverless.service.stepFunctions = {};
-      let expectedMessage = '';
-      expectedMessage += `${chalk.yellow.underline('Serverless StepFunctions OutPuts')}\n`;
-      expectedMessage += `${chalk.yellow('endpoints:')}`;
-      expectedMessage += '\n';
+      const expectedMessage = '';
       const message = serverlessStepFunctions.display();
-      expect(consoleLogStub.calledOnce).to.equal(true);
+      expect(consoleLogStub.calledOnce).to.equal(false);
       expect(message).to.equal(expectedMessage);
     });
 
@@ -337,12 +334,9 @@ describe('#index', () => {
           },
         },
       };
-      let expectedMessage = '';
-      expectedMessage += `${chalk.yellow.underline('Serverless StepFunctions OutPuts')}\n`;
-      expectedMessage += `${chalk.yellow('endpoints:')}`;
-      expectedMessage += '\n';
+      const expectedMessage = '';
       const message = serverlessStepFunctions.display();
-      expect(consoleLogStub.calledOnce).to.equal(true);
+      expect(consoleLogStub.calledOnce).to.equal(false);
       expect(message).to.equal(expectedMessage);
     });
 
@@ -359,12 +353,9 @@ describe('#index', () => {
           },
         },
       };
-      let expectedMessage = '';
-      expectedMessage += `${chalk.yellow.underline('Serverless StepFunctions OutPuts')}\n`;
-      expectedMessage += `${chalk.yellow('endpoints:')}`;
-      expectedMessage += '\n';
+      const expectedMessage = '';
       const message = serverlessStepFunctions.display();
-      expect(consoleLogStub.calledOnce).to.equal(true);
+      expect(consoleLogStub.calledOnce).to.equal(false);
       expect(message).to.equal(expectedMessage);
     });
   });


### PR DESCRIPTION
Display nothing instead of:

```
Serverless StepFunctions OutPuts
endpoints:

```

Because that information is useless if user never configured endpoints.