### PR TITLE
Add support for CloudFormation intrinsic function for role

### DIFF
--- a/lib/deploy/stepFunctions/compileStateMachines.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.js
@@ -2,6 +2,11 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 
+function isIntrinsic(obj) {
+  const isObject = typeof obj === 'object';
+  return isObject && Object.keys(obj).some((k) => k.startsWith('Fn::'));
+}
+
 module.exports = {
   compileStateMachines() {
     if (this.isStateMachines()) {
@@ -39,17 +44,16 @@ module.exports = {
               throw new this.serverless.classes
               .Error(errorMessage);
             }
+          } else if (isIntrinsic(stateMachineObj.role)) {
+            RoleArn = JSON.stringify(stateMachineObj.role);
           } else {
-            if (typeof stateMachineObj.role === 'object' && Object.keys(stateMachineObj.role).some(function(k){return k.startsWith('Fn::')}) ){
-              RoleArn = JSON.stringify(stateMachineObj.role)
-            } else {
-              const errorMessage = [
-                `role property in stateMachine "${stateMachineName}" is neither a string nor a CloudFormation intrinsic function`,
-                ' Please check the README for more info.',
-              ].join('');
-              throw new this.serverless.classes
-              .Error(errorMessage);
-            }
+            const errorMessage = [
+              `role property in stateMachine "${stateMachineName}" is neither a string`,
+              ' nor a CloudFormation intrinsic function',
+              ' Please check the README for more info.',
+            ].join('');
+            throw new this.serverless.classes
+            .Error(errorMessage);
           }
         } else {
           RoleArn = '{ "Fn::GetAtt": ["IamRoleStateMachineExecution", "Arn"] }';

--- a/lib/deploy/stepFunctions/compileStateMachines.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.js
@@ -40,12 +40,16 @@ module.exports = {
               .Error(errorMessage);
             }
           } else {
-            const errorMessage = [
-              `role property in stateMachine "${stateMachineName}" is not an string`,
-              ' Please check the README for more info.',
-            ].join('');
-            throw new this.serverless.classes
-            .Error(errorMessage);
+            if (typeof stateMachineObj.role === 'object' && Object.keys(stateMachineObj.role).some(function(k){return k.startsWith('Fn::')}) ){
+              RoleArn = JSON.stringify(stateMachineObj.role)
+            } else {
+              const errorMessage = [
+                `role property in stateMachine "${stateMachineName}" is neither a string nor a CloudFormation intrinsic function`,
+                ' Please check the README for more info.',
+              ].join('');
+              throw new this.serverless.classes
+              .Error(errorMessage);
+            }
           }
         } else {
           RoleArn = '{ "Fn::GetAtt": ["IamRoleStateMachineExecution", "Arn"] }';

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -240,25 +240,25 @@ describe('#compileStateMachines', () => {
         myStateMachine1: {
           name: 'stateMachineWithIntrinsicRole',
           definition: 'definition1\n',
-          role: {"Fn::Attr": ["RoleID","Arn"]}
-        }
+          role: { 'Fn::Attr': ['RoleID', 'Arn'] },
+        },
       },
     };
     serverlessStepFunctions.compileStateMachines();
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
       .StateMachineWithIntrinsicRole.Properties.RoleArn
-    ).to.deep.equal({"Fn::Attr": ["RoleID","Arn"]});
+    ).to.deep.equal({ 'Fn::Attr': ['RoleID', 'Arn'] });
   });
 
-  it('should throw error if role property is neither string nor CloudFormation intrinsic functions', () => {
+  it('should throw error if role property is neither string nor intrinsic functions', () => {
     serverless.service.stepFunctions = {
       stateMachines: {
         myStateMachine1: {
           name: 'stateMachineWithIntrinsicRole',
           definition: 'definition1\n',
-          role: {"XXX": ["RoleID","Arn"]}
-        }
+          role: { XXX: ['RoleID', 'Arn'] },
+        },
       },
     };
     expect(() => serverlessStepFunctions.compileStateMachines()).to.throw(Error);

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -234,6 +234,36 @@ describe('#compileStateMachines', () => {
     ).to.equal('StateMachineBeta2');
   });
 
+  it('should respect CloudFormation intrinsic functions for role property', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          name: 'stateMachineWithIntrinsicRole',
+          definition: 'definition1\n',
+          role: {"Fn::Attr": ["RoleID","Arn"]}
+        }
+      },
+    };
+    serverlessStepFunctions.compileStateMachines();
+    expect(serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .StateMachineWithIntrinsicRole.Properties.RoleArn
+    ).to.deep.equal({"Fn::Attr": ["RoleID","Arn"]});
+  });
+
+  it('should throw error if role property is neither string nor CloudFormation intrinsic functions', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          name: 'stateMachineWithIntrinsicRole',
+          definition: 'definition1\n',
+          role: {"XXX": ["RoleID","Arn"]}
+        }
+      },
+    };
+    expect(() => serverlessStepFunctions.compileStateMachines()).to.throw(Error);
+  });
+
   it('should throw error when definition property is not given', () => {
     serverless.service.stepFunctions = {
       stateMachines: {


### PR DESCRIPTION
This PR adds support for CloudFormation intrinsic functions to the ```role``` property, such for example the following sytanx is supported:

```yaml
role: {"Fn::GetAtt": ["MyRoleId", "Arn"]}
role: {Fn::GetAtt: [MyRoleId, Arn]}
role:
   Fn::GetAtt:
   - MyRoleId
   - Arn
```
Having this feature in place, it is now possible to use (refer to) IAM roles which are defined in the ```Resources``` section of the ```serverless.yml``` file.
