### PR TITLE
Populating object before parsing step function

### DIFF
--- a/lib/yamlParser.js
+++ b/lib/yamlParser.js
@@ -16,19 +16,14 @@ module.exports = {
       .then((serverlessFileParam) => {
         this.serverless.variables.populateObject(serverlessFileParam).then((parsedObject) => {
           this.serverless.service.stepFunctions = {};
-          try {
-            this.serverless.service.stepFunctions.stateMachines
+          this.serverless.service.stepFunctions.stateMachines
               = parsedObject.stepFunctions
             && parsedObject.stepFunctions.stateMachines
               ? parsedObject.stepFunctions.stateMachines : {};
-            this.serverless.service.stepFunctions.activities
+          this.serverless.service.stepFunctions.activities
               = parsedObject.stepFunctions
             && parsedObject.stepFunctions.activities
               ? parsedObject.stepFunctions.activities : [];
-          } catch (e) {
-            throw new this.serverless.classes
-              .Error('stateMachine or activity not found in this Service');
-          }
 
           if (!this.serverless.pluginManager.cliOptions.stage) {
             this.serverless.pluginManager.cliOptions.stage = this.options.stage

--- a/lib/yamlParser.js
+++ b/lib/yamlParser.js
@@ -14,30 +14,37 @@ module.exports = {
     return this.serverless.yamlParser
       .parse(serverlessYmlPath)
       .then((serverlessFileParam) => {
-        this.serverless.service.stepFunctions = {};
-        this.serverless.service.stepFunctions.stateMachines
-          = serverlessFileParam.stepFunctions
-          && serverlessFileParam.stepFunctions.stateMachines
-          ? serverlessFileParam.stepFunctions.stateMachines : {};
-        this.serverless.service.stepFunctions.activities
-          = serverlessFileParam.stepFunctions
-          && serverlessFileParam.stepFunctions.activities
-          ? serverlessFileParam.stepFunctions.activities : [];
+        this.serverless.variables.populateObject(serverlessFileParam).then((parsedObject) => {
+          this.serverless.service.stepFunctions = {};
+          try {
+            this.serverless.service.stepFunctions.stateMachines
+              = parsedObject.stepFunctions
+            && parsedObject.stepFunctions.stateMachines
+              ? parsedObject.stepFunctions.stateMachines : {};
+            this.serverless.service.stepFunctions.activities
+              = parsedObject.stepFunctions
+            && parsedObject.stepFunctions.activities
+              ? parsedObject.stepFunctions.activities : [];
+          } catch (e) {
+            throw new this.serverless.classes
+              .Error('stateMachine or activity not found in this Service');
+          }
 
-        if (!this.serverless.pluginManager.cliOptions.stage) {
-          this.serverless.pluginManager.cliOptions.stage = this.options.stage
+          if (!this.serverless.pluginManager.cliOptions.stage) {
+            this.serverless.pluginManager.cliOptions.stage = this.options.stage
             || (this.serverless.service.provider && this.serverless.service.provider.stage)
             || 'dev';
-        }
+          }
 
-        if (!this.serverless.pluginManager.cliOptions.region) {
-          this.serverless.pluginManager.cliOptions.region = this.options.region
+          if (!this.serverless.pluginManager.cliOptions.region) {
+            this.serverless.pluginManager.cliOptions.region = this.options.region
             || (this.serverless.service.provider && this.serverless.service.provider.region)
             || 'us-east-1';
-        }
+          }
 
-        this.serverless.variables.populateService(this.serverless.pluginManager.cliOptions);
-        return BbPromise.resolve();
+          this.serverless.variables.populateService(this.serverless.pluginManager.cliOptions);
+          return BbPromise.resolve();
+        });
       });
   },
 

--- a/lib/yamlParser.test.js
+++ b/lib/yamlParser.test.js
@@ -22,9 +22,17 @@ describe('#yamlParse', () => {
   describe('#yamlParse()', () => {
     let yamlParserStub;
     let populateServiceStub;
+    let yamlObjectParserStub;
     beforeEach(() => {
       populateServiceStub = sinon.stub(serverlessStepFunctions.serverless.variables,
       'populateService').returns(BbPromise.resolve());
+      yamlObjectParserStub = sinon.stub(serverlessStepFunctions.serverless.variables,
+        'populateObject').returns(BbPromise.resolve({
+          stepFunctions: {
+            stateMachines: 'stepFunctions',
+            activities: 'my-activity',
+          },
+        }));
       yamlParserStub = sinon.stub(serverlessStepFunctions.serverless.yamlParser, 'parse')
       .returns(BbPromise.resolve({
         stepFunctions: {
@@ -33,6 +41,12 @@ describe('#yamlParse', () => {
         },
       }));
       serverlessStepFunctions.serverless.config.servicePath = 'servicePath';
+    });
+
+    afterEach(() => {
+      serverlessStepFunctions.serverless.yamlParser.parse.restore();
+      serverlessStepFunctions.serverless.variables.populateService.restore();
+      serverlessStepFunctions.serverless.variables.populateObject.restore();
     });
 
     it('should default to dev when stage and provider are not defined', () => {
@@ -74,39 +88,49 @@ describe('#yamlParse', () => {
       serverlessStepFunctions.yamlParse()
       .then(() => {
         expect(yamlParserStub.calledOnce).to.be.equal(false);
+        expect(yamlObjectParserStub.calledOnce).to.be.equal(false);
         expect(populateServiceStub.calledOnce).to.be.equal(false);
         expect(serverless.service.stepFunctions).to.be.undefined; // eslint-disable-line
-        serverlessStepFunctions.serverless.yamlParser.parse.restore();
-        serverlessStepFunctions.serverless.variables.populateService.restore();
       });
     });
 
     it('should create corresponding when stepfunctions param are given', () => {
+      serverlessStepFunctions.serverless.variables.populateObject.restore();
+      yamlObjectParserStub = sinon.stub(serverlessStepFunctions.serverless.variables,
+        'populateObject').returns(BbPromise.resolve({
+          stepFunctions: {
+            stateMachines: 'stepFunctions',
+            activities: 'my-activity',
+          },
+        }));
       serverlessStepFunctions.yamlParse()
       .then(() => {
         expect(yamlParserStub.calledOnce).to.be.equal(true);
+        expect(yamlObjectParserStub.calledOnce).to.be.equal(true);
         expect(populateServiceStub.calledOnce).to.be.equal(true);
         expect(serverless.service.stepFunctions.stateMachines).to.be.equal('stepFunctions');
         expect(serverless.service.stepFunctions.activities).to.be.equal('my-activity');
-        serverlessStepFunctions.serverless.yamlParser.parse.restore();
-        serverlessStepFunctions.serverless.variables.populateService.restore();
       });
     });
 
     it('should create empty object when stepfunctions param are not given', () => {
       serverlessStepFunctions.serverless.yamlParser.parse.restore();
+      serverlessStepFunctions.serverless.variables.populateObject.restore();
       yamlParserStub = sinon.stub(serverlessStepFunctions.serverless.yamlParser, 'parse')
       .returns(BbPromise.resolve({
         stepFunctions: {},
       }));
+      yamlObjectParserStub = sinon.stub(serverless.variables,
+        'populateObject').returns(BbPromise.resolve({
+          stepFunctions: {},
+        }));
       serverlessStepFunctions.yamlParse()
       .then(() => {
         expect(yamlParserStub.calledOnce).to.be.equal(true);
+        expect(yamlObjectParserStub.calledOnce).to.be.equal(true);
         expect(populateServiceStub.calledOnce).to.be.equal(true);
         expect(serverless.service.stepFunctions.stateMachines).to.be.deep.equal({});
         expect(serverless.service.stepFunctions.activities).to.be.deep.equal([]);
-        serverlessStepFunctions.serverless.yamlParser.parse.restore();
-        serverlessStepFunctions.serverless.variables.populateService.restore();
       });
     });
   });


### PR DESCRIPTION
Currently this plugin is setting the step function, state machine, and activity keys before the `serverless.yml` file has populated the variables.

This allows you to organize serverless.yml like such:

```
stepFunctions:
  stateMachines:
    ${file(config/env/${opt:stage}.yml):stateMachines}
```

but _not_ like this
```
stepFunctions:
  ${file(config/env/${opt:stage}.yml):stepFunctions}
```

This proposed change populates the variables before determining whether or not a step function exists in the given config.