### PR TITLE
Add support for custom body mapping templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,32 @@ stepFunctions:
 
 Configuring the cors property sets Access-Control-Allow-Origin, Access-Control-Allow-Headers, Access-Control-Allow-Methods,Access-Control-Allow-Credentials headers in the CORS preflight response.
 
+#### Customizing request body mapping templates
+
+The plugin generates default body mapping templates for `application/json` and `application/x-www-form-urlencoded` content types. If you'd like to add more content types or customize the default ones, you can do so by including them in `serverless.yml`:
+
+```yml
+stepFunctions:
+  stateMachines:
+    hello:
+      events:
+        - http:
+            path: posts/create
+            method: POST
+            request:
+              template:
+                application/json: |
+                  #set( $body = $util.escapeJavaScript($input.json('$')) )
+                  #set( $name = $util.escapeJavaScript($input.json('$.data.attributes.order_id')) )
+                  {
+                    "input": "$body",
+                    "name": "$name",
+                    "stateMachineArn":"arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:processOrderFlow-${opt:stage}"
+                  }
+      name: processOrderFlow-${opt:stage}
+      definition:
+```
+
 #### Send request to an API
 You can input an value as json in request body, the value is passed as the input value of your statemachine
 

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -43,7 +43,6 @@ module.exports = {
   },
 
   getMethodIntegration(stateMachineName, customName, http) {
-    const stateMachineLogicalId = this.getStateMachineLogicalId(stateMachineName, customName);
     const apiToStepFunctionsIamRoleLogicalId = this.getApiToStepFunctionsIamRoleLogicalId();
     const integration = {
       IntegrationHttpMethod: 'POST',
@@ -67,32 +66,7 @@ module.exports = {
         ],
       },
       PassthroughBehavior: 'NEVER',
-      RequestTemplates: {
-        'application/json': {
-          'Fn::Join': [
-            '', [
-              "#set( $body = $util.escapeJavaScript($input.json('$')) ) \n\n",
-              '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
-              {
-                Ref: `${stateMachineLogicalId}`,
-              },
-              '"}',
-            ],
-          ],
-        },
-        'application/x-www-form-urlencoded': {
-          'Fn::Join': [
-            '', [
-              "#set( $body = $util.escapeJavaScript($input.json('$')) ) \n\n",
-              '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
-              {
-                Ref: `${stateMachineLogicalId}`,
-              },
-              '"}',
-            ],
-          ],
-        },
-      },
+      RequestTemplates: this.getIntegrationRequestTemplates(stateMachineName, customName, http)
     };
 
     const integrationResponse = {
@@ -132,6 +106,36 @@ module.exports = {
         Integration: integration,
       },
     };
+  },
+
+  getIntegrationRequestTemplates(stateMachineName, customName, http) {
+    const stateMachineLogicalId = this.getStateMachineLogicalId(stateMachineName, customName);
+    return {
+      'application/json': {
+        'Fn::Join': [
+          '', [
+            "#set( $body = $util.escapeJavaScript($input.json('$')) ) \n\n",
+            '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
+            {
+              Ref: `${stateMachineLogicalId}`,
+            },
+            '"}',
+          ],
+        ],
+      },
+      'application/x-www-form-urlencoded': {
+        'Fn::Join': [
+          '', [
+            "#set( $body = $util.escapeJavaScript($input.json('$')) ) \n\n",
+            '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
+            {
+              Ref: `${stateMachineLogicalId}`,
+            },
+            '"}',
+          ],
+        ],
+      },
+    }
   },
 
   getMethodResponses(http) {

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -113,7 +113,7 @@ module.exports = {
     return Object.assign(
       defaultRequestTemplates,
       _.get(http, ['request', 'template'])
-     );
+    );
   },
 
   getDefaultRequestTemplates(stateMachineName, customName) {

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -66,7 +66,7 @@ module.exports = {
         ],
       },
       PassthroughBehavior: 'NEVER',
-      RequestTemplates: this.getIntegrationRequestTemplates(stateMachineName, customName, http)
+      RequestTemplates: this.getIntegrationRequestTemplates(stateMachineName, customName, http),
     };
 
     const integrationResponse = {
@@ -120,8 +120,8 @@ module.exports = {
     const stateMachineLogicalId = this.getStateMachineLogicalId(stateMachineName, customName);
     return {
       'application/json': this.buildDefaultRequestTemplate(stateMachineLogicalId),
-      'application/x-www-form-urlencoded': this.buildDefaultRequestTemplate(stateMachineLogicalId)
-    }
+      'application/x-www-form-urlencoded': this.buildDefaultRequestTemplate(stateMachineLogicalId),
+    };
   },
 
   buildDefaultRequestTemplate(stateMachineLogicalId) {
@@ -136,7 +136,7 @@ module.exports = {
           '"}',
         ],
       ],
-    }
+    };
   },
 
   getMethodResponses(http) {

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -109,32 +109,33 @@ module.exports = {
   },
 
   getIntegrationRequestTemplates(stateMachineName, customName, http) {
+    const defaultRequestTemplates = this.getDefaultRequestTemplates(stateMachineName, customName);
+    return Object.assign(
+      defaultRequestTemplates,
+      _.get(http, ['request', 'template'])
+     );
+  },
+
+  getDefaultRequestTemplates(stateMachineName, customName) {
     const stateMachineLogicalId = this.getStateMachineLogicalId(stateMachineName, customName);
     return {
-      'application/json': {
-        'Fn::Join': [
-          '', [
-            "#set( $body = $util.escapeJavaScript($input.json('$')) ) \n\n",
-            '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
-            {
-              Ref: `${stateMachineLogicalId}`,
-            },
-            '"}',
-          ],
+      'application/json': this.buildDefaultRequestTemplate(stateMachineLogicalId),
+      'application/x-www-form-urlencoded': this.buildDefaultRequestTemplate(stateMachineLogicalId)
+    }
+  },
+
+  buildDefaultRequestTemplate(stateMachineLogicalId) {
+    return {
+      'Fn::Join': [
+        '', [
+          "#set( $body = $util.escapeJavaScript($input.json('$')) ) \n\n",
+          '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
+          {
+            Ref: `${stateMachineLogicalId}`,
+          },
+          '"}',
         ],
-      },
-      'application/x-www-form-urlencoded': {
-        'Fn::Join': [
-          '', [
-            "#set( $body = $util.escapeJavaScript($input.json('$')) ) \n\n",
-            '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
-            {
-              Ref: `${stateMachineLogicalId}`,
-            },
-            '"}',
-          ],
-        ],
-      },
+      ],
     }
   },
 

--- a/lib/deploy/events/apiGateway/methods.test.js
+++ b/lib/deploy/events/apiGateway/methods.test.js
@@ -104,75 +104,87 @@ describe('#methods()', () => {
 
   describe('#getIntegrationRequestTemplates()', () => {
     it('should set stateMachinelogical ID in default templates when customName is not set', () => {
-      expect(serverlessStepFunctions.getIntegrationRequestTemplates('stateMachine')
-        ['application/json']['Fn::Join'][1][2].Ref)
+      const requestTemplates = serverlessStepFunctions
+        .getIntegrationRequestTemplates('stateMachine');
+      expect(requestTemplates['application/json']['Fn::Join'][1][2].Ref)
         .to.be.equal('StateMachineStepFunctionsStateMachine');
     });
 
     it('should set custom stateMachinelogical ID in default templates when customName is set',
     () => {
-      expect(serverlessStepFunctions.getIntegrationRequestTemplates('stateMachine', 'custom')
-        ['application/json']['Fn::Join'][1][2].Ref)
+      const requestTemplates = serverlessStepFunctions
+        .getIntegrationRequestTemplates('stateMachine', 'custom');
+      expect(requestTemplates['application/json']['Fn::Join'][1][2].Ref)
         .to.be.equal('Custom');
     });
 
     it('should return the default template for application/json when one is not given', () => {
-      const http_without_request_template = {
+      const httpWithoutRequestTemplate = {
         path: 'foo/bar1',
         method: 'post',
         request: {
           template: {
-            'application/x-www-form-urlencoded': 'custom template'
-          }
-        }
-      }
-      expect(serverlessStepFunctions.getMethodIntegration('stateMachine', undefined, http_without_request_template)
-        .Properties.Integration.RequestTemplates['application/json']['Fn::Join'][1][2].Ref)
+            'application/x-www-form-urlencoded': 'custom template',
+          },
+        },
+      };
+      const requestTemplates = serverlessStepFunctions
+        .getMethodIntegration('stateMachine', undefined, httpWithoutRequestTemplate)
+        .Properties.Integration.RequestTemplates;
+      expect(requestTemplates['application/json']['Fn::Join'][1][2].Ref)
         .to.be.equal('StateMachineStepFunctionsStateMachine');
     });
 
     it('should return a custom template for application/json when one is given', () => {
-      const http_with_request_template = {
+      const httpWithRequestTemplate = {
         path: 'foo/bar1',
         method: 'post',
         request: {
           template: {
-            'application/json': 'custom template'
-          }
-        }
-      }
-      expect(serverlessStepFunctions.getMethodIntegration('stateMachine', undefined, http_with_request_template)
-        .Properties.Integration.RequestTemplates['application/json'])
+            'application/json': 'custom template',
+          },
+        },
+      };
+      const requestTemplates = serverlessStepFunctions
+        .getMethodIntegration('stateMachine', undefined, httpWithRequestTemplate)
+        .Properties.Integration.RequestTemplates;
+      expect(requestTemplates['application/json'])
         .to.be.equal('custom template');
     });
 
-    it('should return the default template for application/x-www-form-urlencoded when one is not given', () => {
-      const http_without_request_template = {
+    it('should return the default for application/x-www-form-urlencoded when one is not given',
+    () => {
+      const httpWithoutRequestTemplate = {
         path: 'foo/bar1',
         method: 'post',
         request: {
           template: {
-            'application/json': 'custom template'
-          }
-        }
-      }
-      expect(serverlessStepFunctions.getMethodIntegration('stateMachine', undefined, http_without_request_template)
-        .Properties.Integration.RequestTemplates['application/x-www-form-urlencoded']['Fn::Join'][1][2].Ref)
+            'application/json': 'custom template',
+          },
+        },
+      };
+      const requestTemplates = serverlessStepFunctions
+        .getMethodIntegration('stateMachine', undefined, httpWithoutRequestTemplate)
+        .Properties.Integration.RequestTemplates;
+      expect(requestTemplates['application/x-www-form-urlencoded']['Fn::Join'][1][2].Ref)
         .to.be.equal('StateMachineStepFunctionsStateMachine');
     });
 
-    it('should return a custom template for application/x-www-form-urlencoded when one is given', () => {
-      const http_with_request_template = {
+    it('should return a custom template for application/x-www-form-urlencoded when one is given',
+    () => {
+      const httpWithRequestTemplate = {
         path: 'foo/bar1',
         method: 'post',
         request: {
           template: {
-            'application/x-www-form-urlencoded': 'custom template'
-          }
-        }
-      }
-      expect(serverlessStepFunctions.getMethodIntegration('stateMachine', undefined, http_with_request_template)
-        .Properties.Integration.RequestTemplates['application/x-www-form-urlencoded'])
+            'application/x-www-form-urlencoded': 'custom template',
+          },
+        },
+      };
+      const requestTemplates = serverlessStepFunctions
+        .getMethodIntegration('stateMachine', undefined, httpWithRequestTemplate)
+        .Properties.Integration.RequestTemplates;
+      expect(requestTemplates['application/x-www-form-urlencoded'])
         .to.be.equal('custom template');
     });
   });

--- a/lib/deploy/events/apiGateway/methods.test.js
+++ b/lib/deploy/events/apiGateway/methods.test.js
@@ -82,20 +82,6 @@ describe('#methods()', () => {
         .to.have.property('Integration');
     });
 
-    // Remove these 2 specs
-    it('should set stateMachinelogical ID to RequestTemplates when customName is not set', () => {
-      expect(serverlessStepFunctions.getMethodIntegration('stateMachine').Properties
-        .Integration.RequestTemplates['application/json']['Fn::Join'][1][2].Ref)
-        .to.be.equal('StateMachineStepFunctionsStateMachine');
-    });
-
-    it('should set custom stateMachinelogical ID to RequestTemplates when customName is set',
-    () => {
-      expect(serverlessStepFunctions.getMethodIntegration('stateMachine', 'custom').Properties
-        .Integration.RequestTemplates['application/json']['Fn::Join'][1][2].Ref)
-        .to.be.equal('Custom');
-    });
-
     it('should set Access-Control-Allow-Origin header when cors is true',
     () => {
       expect(serverlessStepFunctions.getMethodIntegration('stateMachine', 'custom', {

--- a/lib/deploy/events/apiGateway/methods.test.js
+++ b/lib/deploy/events/apiGateway/methods.test.js
@@ -82,6 +82,7 @@ describe('#methods()', () => {
         .to.have.property('Integration');
     });
 
+    // Remove these 2 specs
     it('should set stateMachinelogical ID to RequestTemplates when customName is not set', () => {
       expect(serverlessStepFunctions.getMethodIntegration('stateMachine').Properties
         .Integration.RequestTemplates['application/json']['Fn::Join'][1][2].Ref)
@@ -112,6 +113,81 @@ describe('#methods()', () => {
       }).Properties.Integration.IntegrationResponses[0]
       .ResponseParameters['method.response.header.Access-Control-Allow-Origin'])
       .to.equal('\'*\'');
+    });
+  });
+
+  describe('#getIntegrationRequestTemplates()', () => {
+    it('should set stateMachinelogical ID in default templates when customName is not set', () => {
+      expect(serverlessStepFunctions.getIntegrationRequestTemplates('stateMachine')
+        ['application/json']['Fn::Join'][1][2].Ref)
+        .to.be.equal('StateMachineStepFunctionsStateMachine');
+    });
+
+    it('should set custom stateMachinelogical ID in default templates when customName is set',
+    () => {
+      expect(serverlessStepFunctions.getIntegrationRequestTemplates('stateMachine', 'custom')
+        ['application/json']['Fn::Join'][1][2].Ref)
+        .to.be.equal('Custom');
+    });
+
+    it('should return the default template for application/json when one is not given', () => {
+      const http_without_request_template = {
+        path: 'foo/bar1',
+        method: 'post',
+        request: {
+          template: {
+            'application/x-www-form-urlencoded': 'custom template'
+          }
+        }
+      }
+      expect(serverlessStepFunctions.getMethodIntegration('stateMachine', undefined, http_without_request_template)
+        .Properties.Integration.RequestTemplates['application/json']['Fn::Join'][1][2].Ref)
+        .to.be.equal('StateMachineStepFunctionsStateMachine');
+    });
+
+    it('should return a custom template for application/json when one is given', () => {
+      const http_with_request_template = {
+        path: 'foo/bar1',
+        method: 'post',
+        request: {
+          template: {
+            'application/json': 'custom template'
+          }
+        }
+      }
+      expect(serverlessStepFunctions.getMethodIntegration('stateMachine', undefined, http_with_request_template)
+        .Properties.Integration.RequestTemplates['application/json'])
+        .to.be.equal('custom template');
+    });
+
+    it('should return the default template for application/x-www-form-urlencoded when one is not given', () => {
+      const http_without_request_template = {
+        path: 'foo/bar1',
+        method: 'post',
+        request: {
+          template: {
+            'application/json': 'custom template'
+          }
+        }
+      }
+      expect(serverlessStepFunctions.getMethodIntegration('stateMachine', undefined, http_without_request_template)
+        .Properties.Integration.RequestTemplates['application/x-www-form-urlencoded']['Fn::Join'][1][2].Ref)
+        .to.be.equal('StateMachineStepFunctionsStateMachine');
+    });
+
+    it('should return a custom template for application/x-www-form-urlencoded when one is given', () => {
+      const http_with_request_template = {
+        path: 'foo/bar1',
+        method: 'post',
+        request: {
+          template: {
+            'application/x-www-form-urlencoded': 'custom template'
+          }
+        }
+      }
+      expect(serverlessStepFunctions.getMethodIntegration('stateMachine', undefined, http_with_request_template)
+        .Properties.Integration.RequestTemplates['application/x-www-form-urlencoded'])
+        .to.be.equal('custom template');
     });
   });
 


### PR DESCRIPTION
Implements support for customizing body mapping templates as discussed in https://github.com/horike37/serverless-step-functions/issues/92.