### PR TITLE
Fix ApiGateway parsing error with single Quotes

### DIFF
--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -138,7 +138,7 @@ module.exports = {
       'Fn::Join': [
         '', [
           // eslint-disable-next-line max-len
-          "#set( $body = $util.escapeJavaScript($input.json('$')).replaceAll(\"\\'\", \"'\") ) \n\n",
+          "#set( $body = $util.escapeJavaScript($input.json('$')).replaceAll(\"\\\\'\", \"'\") ) \n\n",
           '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
           {
             Ref: `${stateMachineLogicalId}`,

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -137,7 +137,7 @@ module.exports = {
     return {
       'Fn::Join': [
         '', [
-          '#set( $body = $util.escapeJavaScript($input.json(\'$\')).replaceAll("\\\\'", "\'") ) \n\n',
+          "#set( $body = $util.escapeJavaScript($input.json('$')).replaceAll(\"\\'\", \"'\") ) \n\n",
           '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
           {
             Ref: `${stateMachineLogicalId}`,

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -137,6 +137,7 @@ module.exports = {
     return {
       'Fn::Join': [
         '', [
+	  // eslint-disable-next-line max-len
           "#set( $body = $util.escapeJavaScript($input.json('$')).replaceAll(\"\\'\", \"'\") ) \n\n",
           '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
           {

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -137,7 +137,7 @@ module.exports = {
     return {
       'Fn::Join': [
         '', [
-          "#set( $body = $util.escapeJavaScript($input.json('$')) ) \n\n",
+          '#set( $body = $util.escapeJavaScript($input.json(\'$\')).replaceAll("\\\\'", "\'") ) \n\n',
           '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
           {
             Ref: `${stateMachineLogicalId}`,

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -137,7 +137,7 @@ module.exports = {
     return {
       'Fn::Join': [
         '', [
-	  // eslint-disable-next-line max-len
+          // eslint-disable-next-line max-len
           "#set( $body = $util.escapeJavaScript($input.json('$')).replaceAll(\"\\'\", \"'\") ) \n\n",
           '{"input": "$body","name": "$context.requestId","stateMachineArn":"',
           {


### PR DESCRIPTION
Hello i wrote this ticket #140 and try to fix the template.

I ~~**could NOT test**~~ this code changes, but i did it manually inside my api gateway template and it works.

the final template should look likes this

```
#set( $body = $util.escapeJavaScript($input.json('$')).replaceAll("\\'", "'") ) 

{"input": "$body","name": "$context.requestId","stateMachineArn":"arn:aws:states:eu-central-1:xxx:stateMachine-xxx}
```

I tested it with a deployment and it works as expected