### PR TITLE
Refactor function resource arn regex to only allow valid characters

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -12,7 +12,7 @@ module.exports = {
       customRolesProvided.push('role' in stateMachineObj);
 
       const stateMachineJson = JSON.stringify(stateMachineObj);
-      const regex = new RegExp(/"Resource":"([a-z:#{}_\-.]*)"/gi);
+      const regex = new RegExp(/"Resource":"([\w\-:*]*)"/gi);
       let match = regex.exec(stateMachineJson);
       while (match !== null) {
         functionArns.push(match[1]);

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -87,8 +87,9 @@ describe('#compileIamRole', () => {
   });
 
   it('should give invokeFunction permission for only functions referenced by state machine', () => {
-    const helloLambda = 'arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:hello';
-    const worldLambda = 'arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:world';
+    const helloLambda = 'arn:aws:lambda:123:*:function:hello';
+    const worldLambda = 'arn:aws:lambda:*:*:function:world';
+    const fooLambda = 'arn:aws:lambda:us-west-2::function:foo_';
     serverless.service.stepFunctions = {
       stateMachines: {
         myStateMachine1: {
@@ -117,6 +118,19 @@ describe('#compileIamRole', () => {
             },
           },
         },
+        myStateMachine3: {
+          name: 'stateMachineBeta3',
+          definition: {
+            StartAt: 'Foo',
+            States: {
+              Hello: {
+                Type: 'Task',
+                Resource: fooLambda,
+                End: true,
+              },
+            },
+          },
+        },
       },
     };
 
@@ -125,6 +139,6 @@ describe('#compileIamRole', () => {
       .provider.compiledCloudFormationTemplate.Resources.IamRoleStateMachineExecution
       .Properties.Policies[0];
     expect(policy.PolicyDocument.Statement[0].Resource)
-      .to.be.deep.equal([helloLambda, worldLambda]);
+      .to.be.deep.equal([helloLambda, worldLambda, fooLambda]);
   });
 });


### PR DESCRIPTION
- There is a bug with the resource field being empty reported here: https://github.com/horike37/serverless-step-functions/issues/146
- This is due to an issue with the regex not allowing numbers/* character which is common in function arn's.
- I refactored the regex to only allow valid characters for a function arn.