### PR TITLE
Service endpoint fix

### DIFF
--- a/lib/deploy/events/apiGateway/deployment.js
+++ b/lib/deploy/events/apiGateway/deployment.js
@@ -27,7 +27,9 @@ module.exports = {
             [
               'https://',
               this.provider.getApiGatewayRestApiId(),
-              `.execute-api.${this.options.region}.amazonaws.com/${this.options.stage}`,
+              `.execute-api.${this.options.region}.`,
+              { Ref: 'AWS::URLSuffix' },
+              `/${this.options.stage}`,
             ],
           ],
         },

--- a/lib/deploy/events/apiGateway/deployment.test.js
+++ b/lib/deploy/events/apiGateway/deployment.test.js
@@ -27,53 +27,45 @@ describe('#compileDeployment()', () => {
   });
 
   it('should create a deployment resource', () => serverlessStepFunctions
-    .compileDeployment()
-    .then(() => {
+    .compileDeployment().then(() => {
       const apiGatewayDeploymentLogicalId = Object
         .keys(serverlessStepFunctions.serverless.service.provider
           .compiledCloudFormationTemplate.Resources)[0];
 
       expect(
         serverlessStepFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources[apiGatewayDeploymentLogicalId],
-      )
-        .to
-        .deep
-        .equal({
-          Type: 'AWS::ApiGateway::Deployment',
-          DependsOn: ['method-dependency1', 'method-dependency2'],
-          Properties: {
-            RestApiId: { Ref: serverlessStepFunctions.apiGatewayRestApiLogicalId },
-            StageName: 'dev',
-          },
-        });
-    }),
+          .Resources[apiGatewayDeploymentLogicalId]
+      ).to.deep.equal({
+        Type: 'AWS::ApiGateway::Deployment',
+        DependsOn: ['method-dependency1', 'method-dependency2'],
+        Properties: {
+          RestApiId: { Ref: serverlessStepFunctions.apiGatewayRestApiLogicalId },
+          StageName: 'dev',
+        },
+      });
+    })
   );
 
   it('should add service endpoint output', () =>
-    serverlessStepFunctions.compileDeployment()
-      .then(() => {
-        expect(
-          serverlessStepFunctions.serverless.service.provider.compiledCloudFormationTemplate
-            .Outputs.ServiceEndpoint,
-        )
-          .to
-          .deep
-          .equal({
-            Description: 'URL of the service endpoint',
-            Value: {
-              'Fn::Join': [
-                '',
-                [
-                  'https://',
-                  { Ref: serverlessStepFunctions.apiGatewayRestApiLogicalId },
-                  '.execute-api.us-east-1.',
-                  { Ref: 'AWS::URLSuffix' },
-                  '/dev',
-                ],
-              ],
-            },
-          });
-      }),
+    serverlessStepFunctions.compileDeployment().then(() => {
+      expect(
+        serverlessStepFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Outputs.ServiceEndpoint
+      ).to.deep.equal({
+        Description: 'URL of the service endpoint',
+        Value: {
+          'Fn::Join': [
+            '',
+            [
+              'https://',
+              { Ref: serverlessStepFunctions.apiGatewayRestApiLogicalId },
+              '.execute-api.us-east-1.',
+              { Ref: 'AWS::URLSuffix' },
+              '/dev',
+            ],
+          ],
+        },
+      });
+    })
   );
 });

--- a/lib/deploy/events/apiGateway/deployment.test.js
+++ b/lib/deploy/events/apiGateway/deployment.test.js
@@ -27,43 +27,53 @@ describe('#compileDeployment()', () => {
   });
 
   it('should create a deployment resource', () => serverlessStepFunctions
-    .compileDeployment().then(() => {
+    .compileDeployment()
+    .then(() => {
       const apiGatewayDeploymentLogicalId = Object
         .keys(serverlessStepFunctions.serverless.service.provider
           .compiledCloudFormationTemplate.Resources)[0];
 
       expect(
         serverlessStepFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources[apiGatewayDeploymentLogicalId]
-      ).to.deep.equal({
-        Type: 'AWS::ApiGateway::Deployment',
-        DependsOn: ['method-dependency1', 'method-dependency2'],
-        Properties: {
-          RestApiId: { Ref: serverlessStepFunctions.apiGatewayRestApiLogicalId },
-          StageName: 'dev',
-        },
-      });
-    })
+          .Resources[apiGatewayDeploymentLogicalId],
+      )
+        .to
+        .deep
+        .equal({
+          Type: 'AWS::ApiGateway::Deployment',
+          DependsOn: ['method-dependency1', 'method-dependency2'],
+          Properties: {
+            RestApiId: { Ref: serverlessStepFunctions.apiGatewayRestApiLogicalId },
+            StageName: 'dev',
+          },
+        });
+    }),
   );
 
   it('should add service endpoint output', () =>
-    serverlessStepFunctions.compileDeployment().then(() => {
-      expect(
-        serverlessStepFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Outputs.ServiceEndpoint
-      ).to.deep.equal({
-        Description: 'URL of the service endpoint',
-        Value: {
-          'Fn::Join': [
-            '',
-            [
-              'https://',
-              { Ref: serverlessStepFunctions.apiGatewayRestApiLogicalId },
-              '.execute-api.us-east-1.amazonaws.com/dev',
-            ],
-          ],
-        },
-      });
-    })
+    serverlessStepFunctions.compileDeployment()
+      .then(() => {
+        expect(
+          serverlessStepFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Outputs.ServiceEndpoint,
+        )
+          .to
+          .deep
+          .equal({
+            Description: 'URL of the service endpoint',
+            Value: {
+              'Fn::Join': [
+                '',
+                [
+                  'https://',
+                  { Ref: serverlessStepFunctions.apiGatewayRestApiLogicalId },
+                  '.execute-api.us-east-1.',
+                  { Ref: 'AWS::URLSuffix' },
+                  '/dev',
+                ],
+              ],
+            },
+          });
+      }),
   );
 });


### PR DESCRIPTION
The ServiceEndpoint output value for endpoints urls generated by the Serverless framework is being overwritten incorrectly by the serverless-step-functions plugin.

I've described the issue in detail here: https://github.com/horike37/serverless-step-functions/issues/149

This PR changes the ServiceEndpoint generation for API gateway deployments to match the output generated by Serverless framework.