### PR TITLE
Avoid alarms logs when no alarms are defined

### DIFF
--- a/lib/deploy/stepFunctions/compileAlarms.js
+++ b/lib/deploy/stepFunctions/compileAlarms.js
@@ -74,6 +74,11 @@ function getCloudWatchAlarms(
 }
 
 function validateConfig(serverless, stateMachineName, alarmsObj) {
+  // no alarms defined at all
+  if (!_.isObject(alarmsObj)) {
+    return false;
+  }
+
   if (!_.isObject(alarmsObj) ||
       !_.isObject(alarmsObj.topics) ||
       !_.isArray(alarmsObj.metrics) ||

--- a/lib/deploy/stepFunctions/compileAlarms.js
+++ b/lib/deploy/stepFunctions/compileAlarms.js
@@ -79,8 +79,7 @@ function validateConfig(serverless, stateMachineName, alarmsObj) {
     return false;
   }
 
-  if (!_.isObject(alarmsObj) ||
-      !_.isObject(alarmsObj.topics) ||
+  if (!_.isObject(alarmsObj.topics) ||
       !_.isArray(alarmsObj.metrics) ||
       !_.every(alarmsObj.metrics, _.isString)) {
     serverless.cli.consoleLog(

--- a/lib/deploy/stepFunctions/compileAlarms.test.js
+++ b/lib/deploy/stepFunctions/compileAlarms.test.js
@@ -2,21 +2,24 @@
 
 const _ = require('lodash');
 const expect = require('chai').expect;
+const sinon = require('sinon');
 const Serverless = require('serverless/lib/Serverless');
 const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider');
 const ServerlessStepFunctions = require('./../../index');
 
 describe('#compileAlarms', () => {
+  let consoleLogSpy;
   let serverless;
   let serverlessStepFunctions;
 
   beforeEach(() => {
+    consoleLogSpy = sinon.spy();
     serverless = new Serverless();
     serverless.servicePath = true;
     serverless.service.service = 'step-functions';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.cli = { consoleLog: console.log };
+    serverless.cli = { consoleLog: consoleLogSpy };
     const options = {
       stage: 'dev',
       region: 'ap-northeast-1',
@@ -87,6 +90,37 @@ describe('#compileAlarms', () => {
     validateCloudWatchAlarm(resources.StateMachineBeta2ExecutionsAbortedAlarm);
     expect(resources).to.have.property('StateMachineBeta2ExecutionThrottledAlarm');
     validateCloudWatchAlarm(resources.StateMachineBeta2ExecutionThrottledAlarm);
+
+    expect(consoleLogSpy.callCount).equal(0);
+  });
+
+  it('should not generate logs when no CloudWatch Alarms are defiened', () => {
+    const genStateMachine = (name) => ({
+      name,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Pass',
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: genStateMachine('stateMachineBeta1'),
+        myStateMachine2: genStateMachine('stateMachineBeta2'),
+      },
+    };
+
+    serverlessStepFunctions.compileAlarms();
+    const resources = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources;
+    expect(_.keys(resources)).to.have.lengthOf(0);
+
+    expect(consoleLogSpy.callCount).equal(0);
   });
 
   it('should not generate CloudWatch Alarms when alarms.topics is missing', () => {
@@ -119,6 +153,8 @@ describe('#compileAlarms', () => {
     const resources = serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources;
     expect(_.keys(resources)).to.have.lengthOf(0);
+
+    expect(consoleLogSpy.callCount).equal(2);
   });
 
   it('should not generate CloudWatch Alarms when alarms.topics is empty', () => {
@@ -152,6 +188,8 @@ describe('#compileAlarms', () => {
     const resources = serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources;
     expect(_.keys(resources)).to.have.lengthOf(0);
+
+    expect(consoleLogSpy.callCount).equal(2);
   });
 
   it('should not generate CloudWatch Alarms when alarms.metrics is missing', () => {
@@ -184,6 +222,8 @@ describe('#compileAlarms', () => {
     const resources = serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources;
     expect(_.keys(resources)).to.have.lengthOf(0);
+
+    expect(consoleLogSpy.callCount).equal(2);
   });
 
   it('should not generate CloudWatch Alarms for unsupported metrics', () => {
@@ -225,5 +265,7 @@ describe('#compileAlarms', () => {
 
     // but invalid metric names are skipped
     expect(_.keys(resources)).to.have.lengthOf(2);
+
+    expect(consoleLogSpy.callCount).equal(2);
   });
 });

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const expect = require('chai').expect;
+const sinon = require('sinon');
 const Serverless = require('serverless/lib/Serverless');
 const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider');
 const ServerlessStepFunctions = require('./../../index');
@@ -16,7 +17,7 @@ describe('#compileIamRole', () => {
     serverless.service.service = 'step-functions';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.cli = { consoleLog: console.log };
+    serverless.cli = { consoleLog: sinon.spy() };
     const options = {
       stage: 'dev',
       region: 'ap-northeast-1',


### PR DESCRIPTION
The way `validateConfig` works will generate some error logs when no alarms are defined at all.

After upgrading to the latest serverless-step-functions we got some logs about alarms but we don't have alarms defined. I think we should not have log about "alarms config is malformed" when no alarms are defined.

Following https://github.com/horike37/serverless-step-functions/pull/167

Sidenote: I've enable `sinon.spy()` instead of `console.log` in `compileIamRole.test.js` to avoid noisy log during tests. I can remove that if you don't agree.