### PR TITLE
fix: adding 'iam:PassRole' permission for ECS

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -100,7 +100,7 @@ function getGluePermissions() {
 
 function getEcsPermissions() {
   return [{
-    action: 'ecs:RunTask,ecs:StopTask,ecs:DescribeTasks',
+    action: 'ecs:RunTask,ecs:StopTask,ecs:DescribeTasks,iam:PassRole',
     resource: '*',
   }, {
     action: 'events:PutTargets,events:PutRule,events:DescribeRule',

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -663,7 +663,7 @@ describe('#compileIamRole', () => {
       .Properties.Policies[0].PolicyDocument.Statement;
 
     const ecsPermissions = statements.filter(s =>
-      _.isEqual(s.Action, ['ecs:RunTask', 'ecs:StopTask', 'ecs:DescribeTasks'])
+      _.isEqual(s.Action, ['ecs:RunTask', 'ecs:StopTask', 'ecs:DescribeTasks', 'iam:PassRole'])
     );
     expect(ecsPermissions).to.have.lengthOf(1);
     expect(ecsPermissions[0].Resource).to.equal('*');


### PR DESCRIPTION
When using `ecs:runTask.sync` task, I have this error when trying to start the job:

> User: arn:aws:sts::01234567890:assumed-role/my-service-staging-IamRoleStateMachineExecut-HOBGIVKJHLN/gaegregerhbeahberg is not authorized to perform: iam:PassRole on resource: arn:aws:iam::01234567890:role/ecsTaskExecutionRole (Service: AmazonECS; Status Code: 400; Error Code: AccessDeniedException; Request ID: 37158697-a9c5-4ce8-8044-812c988dea0a)

The corresponding ASL template:
```
{
  "StartAt": "RunTask",
  "States": {
    "RunTask": {
      "Type": "Task",
      "Resource": "arn:aws:states:::ecs:runTask.sync",
      "Parameters": {
        "Cluster": "my-service-staging-FargateTasksCluster-IGVGYRTYBHUN",
        "TaskDefinition": "arn:aws:ecs:eu-west-1:01234567890:task-definition/my-task:8"
      },
      "End": true
    }
  }
}
```

The fix was to add `iam:PassRole` permission.
