### PR TITLE
fix: match for Ref explicitly

### DIFF
--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -742,4 +742,45 @@ describe('#compileStateMachines', () => {
 
     expect(stateMachine.Properties.DefinitionString).to.not.equal(null);
   });
+
+  it('should not interpret states starting with "Ref" as intrinsic functions #203', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'Test',
+          name: 'test',
+          definition: {
+            StartAt: 'One',
+            States: {
+              One: {
+                Type: 'Wait',
+                Seconds: 10,
+                Next: 'RefreshLead',
+              },
+              RefreshLead: {
+                Type: 'Task',
+                Resource: 'arn:aws:lambda:us-east-1:12345:function:test-dev-lambda',
+                TimeoutSeconds: 60,
+                Next: 'EndState',
+              },
+              EndState: {
+                Type: 'Succeed',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileStateMachines();
+    const stateMachine = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .Test;
+
+    expect(stateMachine.Properties.DefinitionString).to.not.haveOwnProperty('Fn::Sub');
+    const stateMachineObj = JSON.parse(stateMachine.Properties.DefinitionString);
+    expect(stateMachineObj.States).to.haveOwnProperty('One');
+    expect(stateMachineObj.States).to.haveOwnProperty('RefreshLead');
+    expect(stateMachineObj.States).to.haveOwnProperty('EndState');
+  });
 });

--- a/lib/utils/aws.js
+++ b/lib/utils/aws.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 
 function isIntrinsic(obj) {
   return _.isObjectLike(obj) &&
-    Object.keys(obj).some((k) => k.startsWith('Fn::') || k.startsWith('Ref'));
+    Object.keys(obj).some((k) => k.startsWith('Fn::') || k === 'Ref');
 }
 
 module.exports = {


### PR DESCRIPTION
When a state starts with "Ref" the state is interpreted as an intrinsic
function, this fix change the behaviour to look for "Ref" explicitly
instead of startsWith

Closes #203