### PR TITLE
Added ability to consume TemplateResponse for Step Functions API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,27 @@ stepFunctions:
       definition:
 ```
 
+#### Customizing response body mapping templates
+
+If you'd like to add content types or customize the default templates, you can do so by including your custom [API Gateway response mapping template](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html) in `serverless.yml` like so:
+
+```yml
+stepFunctions:
+  stateMachines:
+    hello:
+      events:
+        - http:
+            path: posts/create
+            method: POST
+            response:
+              statusCodes:
+                200:
+                  pattern: ''
+                  template: ''
+                  headers:
+                    Content-Type: "'application/json'"
+```
+
 #### Send request to an API
 
 You can input an value as json in request body, the value is passed as the input value of your statemachine

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -178,13 +178,13 @@ module.exports = {
           StatusCode: 200,
           SelectionPattern: 200,
           ResponseParameters: {},
-          ResponseTemplates: {},
+          ResponseTemplates: [ this.getIntegrationResponseTemplates(200, http) ],
         },
         {
           StatusCode: 400,
           SelectionPattern: 400,
           ResponseParameters: {},
-          ResponseTemplates: {},
+          ResponseTemplates: [ this.getIntegrationResponseTemplates(200, http) ],
         },
       ],
     };
@@ -233,6 +233,22 @@ module.exports = {
       );
     }
     // default template
+    return defaultTemplate;
+  },
+
+  getIntegrationResponseTemplates(StatusCode, http) {
+    const defaultTemplate = {};
+
+    if (_.has(http, "response.statusCodes")) {
+      const response = http.response.statusCodes[StatusCode];
+
+      if (response !== undefined) {
+        if (_.has(response, 'template')) {
+         const template = http.response.statusCodes[StatusCode].template;
+         return Object.assign(defaultTemplate, {'application/json' : template});
+        }
+      }
+    }
     return defaultTemplate;
   },
 

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -178,13 +178,13 @@ module.exports = {
           StatusCode: 200,
           SelectionPattern: 200,
           ResponseParameters: {},
-          ResponseTemplates: [ this.getIntegrationResponseTemplates(200, http) ],
+          ResponseTemplates: [this.getIntegrationResponseTemplates(200, http)],
         },
         {
           StatusCode: 400,
           SelectionPattern: 400,
           ResponseParameters: {},
-          ResponseTemplates: [ this.getIntegrationResponseTemplates(200, http) ],
+          ResponseTemplates: [this.getIntegrationResponseTemplates(200, http)],
         },
       ],
     };
@@ -239,13 +239,13 @@ module.exports = {
   getIntegrationResponseTemplates(StatusCode, http) {
     const defaultTemplate = {};
 
-    if (_.has(http, "response.statusCodes")) {
+    if (_.has(http, 'response.statusCodes')) {
       const response = http.response.statusCodes[StatusCode];
 
       if (response !== undefined) {
         if (_.has(response, 'template')) {
-         const template = http.response.statusCodes[StatusCode].template;
-         return Object.assign(defaultTemplate, {'application/json' : template});
+          const template = http.response.statusCodes[StatusCode].template;
+          return Object.assign(defaultTemplate, { 'application/json': template });
         }
       }
     }

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -184,7 +184,7 @@ module.exports = {
           StatusCode: 400,
           SelectionPattern: 400,
           ResponseParameters: {},
-          ResponseTemplates: [this.getIntegrationResponseTemplates(200, http)],
+          ResponseTemplates: [this.getIntegrationResponseTemplates(400, http)],
         },
       ],
     };

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -238,16 +238,10 @@ module.exports = {
 
   getIntegrationResponseTemplates(StatusCode, http) {
     const defaultTemplate = {};
-
-    if (_.has(http, 'response.statusCodes')) {
-      const response = http.response.statusCodes[StatusCode];
-
-      if (response !== undefined) {
-        if (_.has(response, 'template')) {
-          const template = http.response.statusCodes[StatusCode].template;
-          return Object.assign(defaultTemplate, { 'application/json': template });
-        }
-      }
+    const template = _.get(http, `response.statusCodes.${StatusCode}.template`);
+    
+    if (template) {
+      return Object.assign(defaultTemplate, {'application/json': template});
     }
     return defaultTemplate;
   },


### PR DESCRIPTION
Allows for MappginTemplate in Integration Reponse as:

```
stepFunctions:
  stateMachines:
    helloStep:
      events:
        - http:
            path: hello
            method: POST
            response:
              statusCodes:
                200:
                  pattern: ''
                  template: "#set($inputRoot = $input.path('$'))\n#set($arn = $inputRoot.executionArn)\n#set($lst = $arn.split(\":\"))\n#set($elem = $lst[-1])\n{\"job_id\": $util.escapeJavaScript($elem)}"
                  headers:
                    Content-Type: "'application/json'"
```

allowing to transform response to for example
`{"job_id": 3305683b-8106-11e9-b697-8bac36c37dad}`

