### PR TITLE
refactor: use Joi schema to validate alarms schema

### DIFF
--- a/lib/deploy/stepFunctions/compileAlarms.js
+++ b/lib/deploy/stepFunctions/compileAlarms.js
@@ -1,6 +1,8 @@
 'use strict';
 const _ = require('lodash');
 const BbPromise = require('bluebird');
+const Joi = require('@hapi/joi');
+const schema = require('./compileAlarms.schema');
 
 const cloudWatchMetricNames = {
   executionsTimeOut: 'ExecutionsTimeOut',
@@ -85,29 +87,13 @@ function validateConfig(serverless, stateMachineName, alarmsObj) {
     return false;
   }
 
-  // metrics can be either short form (e.g. "executionsTimeOut") or
-  // long form, which allows you to optionally specify treatMissingData override, e.g.
-  // { "metric": "executionsTimeOut", "treatMissingData": "ignore" }
-  const validateMetric = x =>
-    _.isString(x) ||
-    (_.isObject(x) && _.has(x, 'metric') && _.isString(x.metric));
+  const { error } = Joi.validate(alarmsObj, schema, { allowUnknown: false });
 
-  if (!_.isObject(alarmsObj.topics) ||
-      !_.isArray(alarmsObj.metrics) ||
-      !_.every(alarmsObj.metrics, validateMetric)) {
+  if (error) {
     serverless.cli.consoleLog(
-      `state machine [${stateMachineName}] : alarms config is malformed. ` +
-      'Please see https://github.com/horike37/serverless-step-functions for examples');
-    return false;
-  }
-
-  if (!_.has(alarmsObj.topics, 'ok') &&
-      !_.has(alarmsObj.topics, 'alarm') &&
-      !_.has(alarmsObj.topics, 'insufficientData')) {
-    serverless.cli.consoleLog(
-      `state machine [${stateMachineName}] : alarms config is malformed. ` +
-      "alarms.topics must specify 'ok', 'alarms' or 'insufficientData'"
-    );
+      `State machine [${stateMachineName}] : alarms config is malformed. ` +
+      'Please see https://github.com/horike37/serverless-step-functions for examples. ' +
+      `${error}`);
     return false;
   }
 

--- a/lib/deploy/stepFunctions/compileAlarms.schema.js
+++ b/lib/deploy/stepFunctions/compileAlarms.schema.js
@@ -1,0 +1,44 @@
+const Joi = require('@hapi/joi');
+
+const arn = Joi.alternatives().try(
+  Joi.string(),
+  Joi.object().keys({
+    Ref: Joi.string(),
+  }),
+  Joi.object().keys({
+    'Fn::GetAtt': Joi.array().items(Joi.string()),
+  })
+);
+
+const topics = Joi.object().keys({
+  ok: arn,
+  alarm: arn,
+  insufficientData: arn,
+}).or('ok', 'alarm', 'insufficientData');
+
+const treatMissingData = Joi.string()
+  .allow('missing', 'ignore', 'breaching', 'notBreaching')
+  .default('missing');
+
+const simpleMetric = Joi.string()
+  .allow('executionsTimeOut', 'executionsFailed', 'executionsAborted', 'executionThrottled');
+
+const complexMetric = Joi.object().keys({
+  metric: simpleMetric.required(),
+  treatMissingData,
+});
+
+const metric = Joi.alternatives().try(
+  simpleMetric,
+  complexMetric
+);
+
+const metrics = Joi.array().items(metric).min(1);
+
+const schema = Joi.object().keys({
+  topics: topics.required(),
+  metrics: metrics.required(),
+  treatMissingData,
+});
+
+module.exports = schema;


### PR DESCRIPTION
Using Joi to define and validate the schema for the `alarms` configuration.