### PR TITLE
Feature/support local function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ plugins:
 
 ## Setup
 
-Specifies your statemachine definition using Amazon States Language in a `definition` statement in serverless.yml. You can use CloudFormation intrinsic functions such as `Ref` and `Fn::GetAtt` to reference Lambda functions, SNS topics, SQS queues and DynamoDB tables declared in the same `serverless.yml`.
+Specifies your statemachine definition using Amazon States Language in a `definition` statement in serverless.yml. You can use CloudFormation intrinsic functions such as `Ref` and `Fn::GetAtt` to reference Lambda functions, SNS topics, SQS queues and DynamoDB tables declared in the same `serverless.yml`. Since `Ref` returns different things (ARN, ID, resource name, etc.) depending on the type of CloudFormation resource, please refer to [this page](https://theburningmonk.com/cloudformation-ref-and-getatt-cheatsheet/) to see whether you need to use `Ref` or `Fn::GetAtt`.
 
 Alternatively, you can also provide the raw ARN, or SQS queue URL, or DynamoDB table name as a string. If you need to construct the ARN by hand, then we recommend to use the [serverless-pseudo-parameters](https://www.npmjs.com/package/serverless-pseudo-parameters) plugin together to make your life easier.
 
@@ -99,7 +99,7 @@ stepFunctions:
           HelloWorld1:
             Type: Task
             Resource:
-              Fn::GetAtt: [HelloLambdaFunction, Arn]
+              Fn::GetAtt: [hello, Arn]
             End: true
       dependsOn: CustomIamRole
       tags:
@@ -123,7 +123,7 @@ stepFunctions:
           HelloWorld2:
             Type: Task
             Resource:
-              Fn::GetAtt: [HelloLambdaFunction, Arn]
+              Fn::GetAtt: [hello, Arn]
             End: true
       dependsOn:
         - DynamoDBTable
@@ -139,6 +139,10 @@ plugins:
   - serverless-step-functions
   - serverless-pseudo-parameters
 ```
+
+In the example above, notice that we used `Fn::GetAtt: [hello, Arn]` to get the ARN for the `hello` function defined earlier. This means you don't have to know how the `Serverless` framework converts these local names to CloudFormation logical IDs (e.g. `hello-world` becomes `HelloDashworldLambdaFunction`).
+
+However, if you prefer to work with logical IDs, you can. You can also express the above `Fn::GetAtt` function as `Fn::GetAtt: [HelloLambdaFunction, Arn]`. If you're unfamiliar with the convention the `Serverless` framework uses, then the easiest thing to do is to first run `sls package` then look in the `.serverless` folder for the generated CloudFormation template. Here you can find the logical resource names for the functions you want to reference.
 
 ### Adding a custom name for a stateMachine
 
@@ -691,7 +695,7 @@ functions:
               HelloWorld1:
                 Type: Task
                 Resource:
-                  Fn::GetAtt: [HelloLambdaFunction, Arn]
+                  Fn::GetAtt: [hello, Arn]
                 End: true
 
 
@@ -1008,7 +1012,7 @@ stepFunctions:
           FirstState:
             Type: Task
             Resource:
-              Fn::GetAtt: [HelloLambdaFunction, Arn]
+              Fn::GetAtt: [hello, Arn]
             Next: wait_using_seconds
           wait_using_seconds:
             Type: Wait
@@ -1029,7 +1033,7 @@ stepFunctions:
           FinalState:
             Type: Task
             Resource:
-              Fn::GetAtt: [HelloLambdaFunction, Arn]
+              Fn::GetAtt: [hello, Arn]
             End: true
 plugins:
   - serverless-step-functions
@@ -1053,7 +1057,7 @@ stepFunctions:
           HelloWorld:
             Type: Task
             Resource:
-              Fn::GetAtt: [HelloLambdaFunction, Arn]
+              Fn::GetAtt: [hello, Arn]
             Retry:
             - ErrorEquals:
               - HandledError
@@ -1134,7 +1138,7 @@ stepFunctions:
           HelloWorld:
             Type: Task
             Resource:
-              Fn::GetAtt: [HelloLambdaFunction, Arn]
+              Fn::GetAtt: [hello, Arn]
             Catch:
             - ErrorEquals: ["HandledError"]
               Next: CustomErrorFallback
@@ -1183,7 +1187,7 @@ stepFunctions:
           FirstState:
             Type: Task
             Resource:
-              Fn::GetAtt: [Hello1LambdaFunction, Arn]
+              Fn::GetAtt: [hello, Arn]
             Next: ChoiceState
           ChoiceState:
             Type: Choice
@@ -1198,12 +1202,12 @@ stepFunctions:
           FirstMatchState:
             Type: Task
             Resource:
-              Fn::GetAtt: [Hello2LambdaFunction, Arn]
+              Fn::GetAtt: [hello2, Arn]
             Next: NextState
           SecondMatchState:
             Type: Task
             Resource:
-              Fn::GetAtt: [Hello3LambdaFunction, Arn]
+              Fn::GetAtt: [hello3, Arn]
             Next: NextState
           DefaultState:
             Type: Fail
@@ -1211,7 +1215,7 @@ stepFunctions:
           NextState:
             Type: Task
             Resource:
-              Fn::GetAtt: [Hello4LambdaFunction, Arn]
+              Fn::GetAtt: [hello4, Arn]
             End: true
 plugins:
   - serverless-step-functions

--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const path = require('path');
-const { isIntrinsic } = require('../../utils/aws');
+const { isIntrinsic, translateLocalFunctionNames } = require('../../utils/aws');
 
 function getTaskStates(states) {
   return _.flatMap(states, (state) => {
@@ -177,7 +177,7 @@ function getLambdaPermissions(state) {
     // so you should be able to use Fn::GetAtt here to get the ARN
     return [{
       action: 'lambda:InvokeFunction',
-      resource: functionName,
+      resource: translateLocalFunctionNames.bind(this)(functionName),
     }];
   } if (_.has(functionName, 'Ref')) {
     // because the FunctionName parameter can be either a name or ARN
@@ -188,7 +188,7 @@ function getLambdaPermissions(state) {
         'Fn::Sub': [
           'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}',
           {
-            FunctionName: functionName,
+            FunctionName: translateLocalFunctionNames.bind(this)(functionName),
           },
         ],
       },
@@ -239,16 +239,16 @@ function consolidatePermissionsByResource(permissions) {
     .value(); // unchain
 }
 
-function getIamPermissions(serverless, taskStates) {
+function getIamPermissions(taskStates) {
   return _.flatMap(taskStates, (state) => {
     switch (state.Resource) {
       case 'arn:aws:states:::sqs:sendMessage':
       case 'arn:aws:states:::sqs:sendMessage.waitForTaskToken':
-        return getSqsPermissions(serverless, state);
+        return getSqsPermissions(this.serverless, state);
 
       case 'arn:aws:states:::sns:publish':
       case 'arn:aws:states:::sns:publish.waitForTaskToken':
-        return getSnsPermissions(serverless, state);
+        return getSnsPermissions(this.serverless, state);
 
       case 'arn:aws:states:::dynamodb:updateItem':
         return getDynamoDBPermissions('dynamodb:UpdateItem', state);
@@ -274,16 +274,16 @@ function getIamPermissions(serverless, taskStates) {
 
       case 'arn:aws:states:::lambda:invoke':
       case 'arn:aws:states:::lambda:invoke.waitForTaskToken':
-        return getLambdaPermissions(state);
+        return getLambdaPermissions.bind(this)(state);
 
       default:
         if (isIntrinsic(state.Resource) || state.Resource.startsWith('arn:aws:lambda')) {
           return [{
             action: 'lambda:InvokeFunction',
-            resource: state.Resource,
+            resource: translateLocalFunctionNames.bind(this)(state.Resource),
           }];
         }
-        serverless.cli.consoleLog('Cannot generate IAM policy statement for Task state', state);
+        this.serverless.cli.consoleLog('Cannot generate IAM policy statement for Task state', state);
         return [];
     }
   });
@@ -317,7 +317,7 @@ module.exports = {
       customRolesProvided.push('role' in stateMachineObj);
 
       const taskStates = getTaskStates(stateMachineObj.definition.States);
-      iamPermissions = iamPermissions.concat(getIamPermissions(this.serverless, taskStates));
+      iamPermissions = iamPermissions.concat(getIamPermissions.bind(this)(taskStates));
     });
     if (_.isEqual(_.uniq(customRolesProvided), [true])) {
       return BbPromise.resolve();

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -1261,6 +1261,54 @@ describe('#compileIamRole', () => {
   });
 
   it('should support local function names', () => {
+    const getStateMachine = name => ({
+      name,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Task',
+            Resource: {
+              'Fn::GetAtt': ['hello-world', 'Arn'],
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.functions = {
+      'hello-world': {
+        handler: 'hello-world.handler',
+      },
+    };
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: getStateMachine('sm1'),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.IamRoleStateMachineExecution
+      .Properties.Policies[0].PolicyDocument.Statement;
+
+    const lambdaPermissions = statements.filter(s => _.isEqual(s.Action, ['lambda:InvokeFunction']));
+    expect(lambdaPermissions).to.have.lengthOf(1);
+
+    const lambdaArns = [
+      {
+        'Fn::GetAtt': [
+          'HelloDashworldLambdaFunction',
+          'Arn',
+        ],
+      },
+    ];
+    expect(lambdaPermissions[0].Resource).to.deep.eq(lambdaArns);
+  });
+
+  it('should support local function names for lambda::invoke resource type', () => {
     const getStateMachine = (name, functionName) => ({
       name,
       definition: {
@@ -1284,7 +1332,7 @@ describe('#compileIamRole', () => {
     const lambda1 = { Ref: 'hello-world' };
     const lambda2 = { 'Fn::GetAtt': ['hello-world', 'Arn'] };
 
-    serverless.functions = {
+    serverless.service.functions = {
       'hello-world': {
         handler: 'hello-world.handler',
       },

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -1259,4 +1259,66 @@ describe('#compileIamRole', () => {
     ];
     expect(lambdaPermissions[0].Resource).to.deep.eq(lambdaArns);
   });
+
+  it('should support local function names', () => {
+    const getStateMachine = (name, functionName) => ({
+      name,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Task',
+            Resource: 'arn:aws:states:::lambda:invoke',
+            Parameters: {
+              FunctionName: functionName,
+              Payload: {
+                'ExecutionName.$': '$$.Execution.Name',
+              },
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    const lambda1 = { Ref: 'hello-world' };
+    const lambda2 = { 'Fn::GetAtt': ['hello-world', 'Arn'] };
+
+    serverless.functions = {
+      'hello-world': {
+        handler: 'hello-world.handler',
+      },
+    };
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: getStateMachine('sm1', lambda1),
+        myStateMachine2: getStateMachine('sm2', lambda2),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.IamRoleStateMachineExecution
+      .Properties.Policies[0].PolicyDocument.Statement;
+
+    const lambdaPermissions = statements.filter(s => _.isEqual(s.Action, ['lambda:InvokeFunction']));
+    expect(lambdaPermissions).to.have.lengthOf(1);
+
+    const lambdaArns = [
+      {
+        'Fn::Sub': [
+          'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}',
+          { FunctionName: { Ref: 'HelloDashworldLambdaFunction' } },
+        ],
+      },
+      {
+        'Fn::GetAtt': [
+          'HelloDashworldLambdaFunction',
+          'Arn',
+        ],
+      },
+    ];
+    expect(lambdaPermissions[0].Resource).to.deep.eq(lambdaArns);
+  });
 });

--- a/lib/deploy/stepFunctions/compileStateMachines.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const Chance = require('chance');
-const { isIntrinsic } = require('../../utils/aws');
+const { isIntrinsic, translateLocalFunctionNames } = require('../../utils/aws');
 
 const chance = new Chance();
 
@@ -83,13 +83,17 @@ module.exports = {
               .replace(/\\n|\\r|\\n\\r/g, '');
           } else {
             const functionMappings = Array.from(getIntrinsicFunctions(stateMachineObj.definition));
+            const definitionString = JSON.stringify(stateMachineObj.definition, undefined, 2);
+
             if (_.isEmpty(functionMappings)) {
-              DefinitionString = JSON.stringify(stateMachineObj.definition, undefined, 2);
+              DefinitionString = definitionString;
             } else {
+              const f = translateLocalFunctionNames.bind(this);
+              const params = _.fromPairs(functionMappings.map(([k, v]) => [k, f(v)]));
               DefinitionString = {
                 'Fn::Sub': [
-                  JSON.stringify(stateMachineObj.definition, undefined, 2),
-                  _.fromPairs(functionMappings),
+                  definitionString,
+                  params,
                 ],
               };
             }

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -775,6 +775,6 @@ describe('#compileStateMachines', () => {
     expect(params).to.haveOwnProperty(functionParam);
 
     const refParam = params[functionParam];
-    expect(refParam).to.eql({ 'Fn::GetAtt': ['HelloDashWorldLambdaFunction', 'Arn'] });
+    expect(refParam).to.eql({ 'Fn::GetAtt': ['HelloDashworldLambdaFunction', 'Arn'] });
   });
 });

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -777,4 +777,75 @@ describe('#compileStateMachines', () => {
     const refParam = params[functionParam];
     expect(refParam).to.eql({ 'Fn::GetAtt': ['HelloDashworldLambdaFunction', 'Arn'] });
   });
+
+  it('should support local function names for lambda::invoke resource type', () => {
+    serverless.service.functions = {
+      'hello-world': {
+        handler: 'hello-world.handler',
+      },
+    };
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'Test',
+          definition: {
+            StartAt: 'Lambda1',
+            States: {
+              Lambda1: {
+                Type: 'Task',
+                Resource: 'arn:aws:states:::lambda:invoke',
+                Parameters: {
+                  FunctionName: {
+                    Ref: 'hello-world',
+                  },
+                  Payload: {
+                    'ExecutionName.$': '$$.Execution.Name',
+                  },
+                },
+                Next: 'Lambda2',
+              },
+              Lambda2: {
+                Type: 'Task',
+                Resource: 'arn:aws:states:::lambda:invoke',
+                Parameters: {
+                  FunctionName: {
+                    'Fn::GetAtt': ['hello-world', 'Arn'],
+                  },
+                  Payload: {
+                    'ExecutionName.$': '$$.Execution.Name',
+                  },
+                },
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileStateMachines();
+    const stateMachine = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .Test;
+
+    expect(stateMachine.Properties.DefinitionString).to.haveOwnProperty('Fn::Sub');
+    expect(stateMachine.Properties.DefinitionString['Fn::Sub']).to.have.lengthOf(2);
+
+    const [json, params] = stateMachine.Properties.DefinitionString['Fn::Sub'];
+    const modifiedDefinition = JSON.parse(json);
+
+    const lambda1 = modifiedDefinition.States.Lambda1;
+    expect(lambda1.Parameters.FunctionName.startsWith('${')).to.eq(true);
+    const lambda1ParamName = lambda1.Parameters.FunctionName.replace(/[${}]/g, '');
+    expect(params).to.haveOwnProperty(lambda1ParamName);
+    const lambda1Param = params[lambda1ParamName];
+    expect(lambda1Param).to.eql({ Ref: 'HelloDashworldLambdaFunction' });
+
+    const lambda2 = modifiedDefinition.States.Lambda2;
+    expect(lambda2.Parameters.FunctionName.startsWith('${')).to.eq(true);
+    const lambda2ParamName = lambda2.Parameters.FunctionName.replace(/[${}]/g, '');
+    expect(params).to.haveOwnProperty(lambda2ParamName);
+    const lambda2Param = params[lambda2ParamName];
+    expect(lambda2Param).to.eql({ 'Fn::GetAtt': ['HelloDashworldLambdaFunction', 'Arn'] });
+  });
 });

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -731,4 +731,50 @@ describe('#compileStateMachines', () => {
     expect(stateMachineObj.States).to.haveOwnProperty('RefreshLead');
     expect(stateMachineObj.States).to.haveOwnProperty('EndState');
   });
+
+  it('should support local function names', () => {
+    serverless.service.functions = {
+      'hello-world': {
+        handler: 'hello-world.handler',
+      },
+    };
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'Test',
+          definition: {
+            StartAt: 'Lambda',
+            States: {
+              Lambda: {
+                Type: 'Task',
+                Resource: {
+                  'Fn::GetAtt': ['hello-world', 'Arn'],
+                },
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileStateMachines();
+    const stateMachine = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .Test;
+
+    expect(stateMachine.Properties.DefinitionString).to.haveOwnProperty('Fn::Sub');
+    expect(stateMachine.Properties.DefinitionString['Fn::Sub']).to.have.lengthOf(2);
+
+    const [json, params] = stateMachine.Properties.DefinitionString['Fn::Sub'];
+    const modifiedDefinition = JSON.parse(json);
+
+    const lambda = modifiedDefinition.States.Lambda;
+    expect(lambda.Resource.startsWith('${')).to.eq(true);
+    const functionParam = lambda.Resource.replace(/[${}]/g, '');
+    expect(params).to.haveOwnProperty(functionParam);
+
+    const refParam = params[functionParam];
+    expect(refParam).to.eql({ 'Fn::GetAtt': ['HelloDashWorldLambdaFunction', 'Arn'] });
+  });
 });

--- a/lib/utils/aws.js
+++ b/lib/utils/aws.js
@@ -5,6 +5,39 @@ function isIntrinsic(obj) {
     && Object.keys(obj).some(k => k.startsWith('Fn::') || k === 'Ref');
 }
 
+// translates local function names, e.g. hello-world
+// to logical resource name, e.g. HelloDashworldLambdaFunction
+function translateLocalFunctionNames(value) {
+  const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+  const functions = this.serverless.service.functions;
+
+  const translate = (logicalId) => {
+    if (!_.has(resources, logicalId) && _.has(functions, logicalId)) {
+      const functionName = logicalId;
+      return this.provider.naming.getLambdaLogicalId(functionName);
+    }
+
+    return logicalId;
+  };
+
+  if (_.has(value, 'Ref')) {
+    const logicalId = value.Ref;
+    return {
+      Ref: translate(logicalId),
+    };
+  }
+
+  if (_.has(value, 'Fn::GetAtt')) {
+    const [logicalId, prop] = value['Fn::GetAtt'];
+    return {
+      'Fn::GetAtt': [translate(logicalId), prop],
+    };
+  }
+
+  return value;
+}
+
 module.exports = {
   isIntrinsic,
+  translateLocalFunctionNames,
 };


### PR DESCRIPTION
Closes #230

This PR lets you use the local function names (e.g. `hello-world`) instead of logical IDs (e.g. `HelloDashworldLambdaFunction`) which is always a bit confusing to newcomers (and myself!) since it forces you to know how Serverless framework translates those local function names - which makes it a leaky abstraction.

e.g.

```yml
functions:
  hello-world:
    handler: hello-world.js

stepFunctions:
  stateMachines:
    myStateMachine:
      definition:
        StartAt: A
        States:
          A:
            Type: Task
            Resource:
              Fn::GetAtt: [hello-world, Arn] # instead of HelloDashworldLambdaFunction
            End: true
```