### PR TITLE
feat: reads config option to be compatible with serverless v1.45.0

### DIFF
--- a/lib/yamlParser.js
+++ b/lib/yamlParser.js
@@ -11,7 +11,8 @@ module.exports = {
       return BbPromise.resolve();
     }
 
-    const serverlessYmlPath = path.join(servicePath, 'serverless.yml');
+    const serviceFileName = this.serverless.config.serverless.service.serviceFilename || 'serverless.yml';
+    const serverlessYmlPath = path.join(servicePath, serviceFileName);
     return this.serverless.yamlParser
       .parse(serverlessYmlPath)
       .then(serverlessFileParam => this.serverless.variables.populateObject(serverlessFileParam)

--- a/lib/yamlParser.test.js
+++ b/lib/yamlParser.test.js
@@ -133,6 +133,27 @@ describe('#yamlParse', () => {
           expect(serverless.service.stepFunctions.activities).to.be.deep.equal([]);
         });
     });
+
+    it('should default to serverless.yml if serviceFileName (--config option) is not passed', () => {
+      const servicePath = serverlessStepFunctions.serverless.config.servicePath;
+      serverlessStepFunctions.serverless.config.serverless.service.serviceFilename = undefined;
+
+      serverlessStepFunctions.yamlParse()
+        .then(() => {
+          expect(yamlParserStub.calledWith(`${servicePath}/serverless.yml`)).to.be.equal(true);
+        });
+    });
+
+    it('should read serviceFileName if passed as --config option', () => {
+      const servicePath = serverlessStepFunctions.serverless.config.servicePath;
+      const fileName = 'other_config.yml';
+      serverlessStepFunctions.serverless.config.serverless.service.serviceFilename = fileName;
+
+      serverlessStepFunctions.yamlParse()
+        .then(() => {
+          expect(yamlParserStub.calledWith(`${servicePath}/${fileName}`)).to.be.equal(true);
+        });
+    });
   });
 
   describe('#getAllStateMachines()', () => {


### PR DESCRIPTION
serverless 1.45.0 adds the ability to pass a `--config` option when deploying a stack so it doesn't always read from `serverless.yml`.  

I added some tests and a condition to yamlParser to check for this option if it has been passed.