### PR TITLE
feat: asl validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is the Serverless Framework plugin for AWS Step Functions.
      - [CloudWatch Alarms](#cloudwatch-alarms)
      - [CloudWatch Notifications](#cloudwatch-notifications)
      - [Blue-Green deployments](#blue-green-deployment)
+     - [Pre-deployment validation](#pre-deployment-validation)
  - [Current Gotcha](#current-gotcha)
  - [Events](#events)
      - [API Gateway](#api-gateway)
@@ -135,6 +136,7 @@ stepFunctions:
   activities:
     - myTask
     - yourTask
+  validate: true # enable pre-deployment definition validation (disabled by default)
 
 plugins:
   - serverless-step-functions
@@ -332,6 +334,15 @@ stepFunctions:
       useExactVersion: true
       definition:
         ...
+```
+
+### Pre-deployment validation
+
+By default, your state machine definition will be validated during deployment by StepFunctions. This can be cumbersome when developing because you have to upload your service for every typo in your definition. In order to go faster, you can enable pre-deployment validation using [asl-validator](https://www.npmjs.com/package/asl-validator) which should detect most of the issues (like a missing state property).
+
+```yaml
+stepFunctions:
+  validate: true
 ```
 
 ## Current Gotcha

--- a/lib/deploy/stepFunctions/compileStateMachines.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const Joi = require('@hapi/joi');
+const aslValidator = require('asl-validator');
 const Chance = require('chance');
 const BbPromise = require('bluebird');
 const schema = require('./compileStateMachines.schema');
@@ -80,6 +81,18 @@ module.exports = {
         }
 
         if (stateMachineObj.definition) {
+          if (this.serverless.service.stepFunctions.validate) {
+            const { isValid, errors } = aslValidator(stateMachineObj.definition);
+            if (isValid) {
+              this.serverless.cli.consoleLog(`✓ State machine "${stateMachineName}" definition is valid`);
+            } else {
+              const errorMessage = [
+                `✕ State machine "${stateMachineName}" definition is invalid:`,
+                JSON.stringify(errors),
+              ].join('\n');
+              throw new this.serverless.classes.Error(errorMessage);
+            }
+          }
           if (typeof stateMachineObj.definition === 'string') {
             DefinitionString = JSON.stringify(stateMachineObj.definition)
               .replace(/\\n|\\r|\\n\\r/g, '');

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -11,6 +11,9 @@ describe('#compileStateMachines', () => {
 
   beforeEach(() => {
     serverless = new Serverless();
+    serverless.cli = {
+      consoleLog: () => {},
+    };
     serverless.servicePath = true;
     serverless.service.service = 'step-functions';
     serverless.service.provider.compiledCloudFormationTemplate = {
@@ -1023,5 +1026,86 @@ describe('#compileStateMachines', () => {
 
       expect(topicArn).to.deep.equal({ Ref: 'MyTopic' });
     });
+  });
+
+  it('should not validate definition if not enabled', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          definition: {
+            StartAt: 'Start',
+            States: {
+              Start: {
+                Type: 'Inexistant type',
+                End: true,
+              },
+            },
+          },
+        },
+      },
+      validate: false,
+    };
+    // Definition is invalid, but should succeed because validate=false
+    serverlessStepFunctions.compileStateMachines();
+  });
+
+  it('should validate definition and pass', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          definition: {
+            StartAt: 'GetAttResource',
+            States: {
+              GetAttResource: {
+                Type: 'Task',
+                Resource: {
+                  'Fn::GetAtt': [
+                    'lambda-name_GetAtt',
+                    'Arn',
+                  ],
+                },
+                Next: 'RefResource',
+              },
+              RefResource: {
+                Type: 'Task',
+                Resource: {
+                  Ref: 'lambda-name_Ref',
+                },
+                Next: 'ArnResource',
+              },
+              ArnResource: {
+                Type: 'Task',
+                Resource: 'arn:aws:lambda:region-1:1234567890:function:lambda-name_Arn',
+                End: true,
+              },
+            },
+          },
+        },
+      },
+      validate: true,
+    };
+    // Definition is valid, should succeed
+    serverlessStepFunctions.compileStateMachines();
+  });
+
+  it('should validate definition and fail', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          definition: {
+            StartAt: 'Start',
+            States: {
+              Start: {
+                Type: 'Inexistant type',
+                End: true,
+              },
+            },
+          },
+        },
+      },
+      validate: true,
+    };
+    // Definition is invalid and validate=true, should throw
+    expect(() => serverlessStepFunctions.compileStateMachines()).to.throw(Error);
   });
 });

--- a/lib/yamlParser.js
+++ b/lib/yamlParser.js
@@ -17,7 +17,9 @@ module.exports = {
       .parse(serverlessYmlPath)
       .then(serverlessFileParam => this.serverless.variables.populateObject(serverlessFileParam)
         .then((parsedObject) => {
-          this.serverless.service.stepFunctions = {};
+          this.serverless.service.stepFunctions = {
+            validate: parsedObject.stepFunctions ? parsedObject.stepFunctions.validate : false,
+          };
           this.serverless.service.stepFunctions.stateMachines = parsedObject.stepFunctions
             && parsedObject.stepFunctions.stateMachines
             ? parsedObject.stepFunctions.stateMachines : {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1191,7 +1191,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true,
       "optional": true
     },
     "ansi": {
@@ -1401,6 +1400,52 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
+    },
+    "asl-validator": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-1.4.0.tgz",
+      "integrity": "sha512-QKOtyi0ShqkLM16DmLedJEXyFlQOLgJYmenaVR3UZwLKZaob/voxbSfoLqpJoUI4N5Z+JKvdZPsaPRO6BlVRTA==",
+      "requires": {
+        "ajv": "^6.10.2",
+        "commander": "^2.20.0",
+        "jsonpath": "^1.0.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+          "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        }
+      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -2689,8 +2734,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
       "version": "4.0.0",
@@ -2969,7 +3013,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-      "dev": true,
       "requires": {
         "esprima": "^2.7.1",
         "estraverse": "^1.9.1",
@@ -2981,8 +3024,7 @@
         "estraverse": {
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-          "dev": true
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
         }
       }
     },
@@ -3313,8 +3355,7 @@
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-      "dev": true
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
     },
     "esquery": {
       "version": "1.0.1",
@@ -3343,8 +3384,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -3659,8 +3699,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5394,6 +5433,23 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "jsonpath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.0.2.tgz",
+      "integrity": "sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==",
+      "requires": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.7.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+          "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5517,7 +5573,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -10925,7 +10980,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.4",
@@ -11257,8 +11311,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -12620,7 +12673,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
       "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-      "dev": true,
       "optional": true,
       "requires": {
         "amdefine": ">=0.0.4"
@@ -12764,6 +12816,14 @@
       "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.2.tgz",
       "integrity": "sha512-0Eyrk6uXW6tg9PYkhi/V/J4zHp33aNyi2hOCmhFLqLTIhbgqWn5jlSzI+IU0VqrZq6+DbHcabQl/WP6P3BG0QA==",
       "dev": true
+    },
+    "static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "requires": {
+        "escodegen": "^1.8.1"
+      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -13421,7 +13481,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -13486,6 +13545,11 @@
           }
         }
       }
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
     },
     "union-value": {
       "version": "1.0.0",
@@ -13832,8 +13896,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrap-ansi": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@hapi/joi": "^15.0.2",
+    "asl-validator": "^1.4.0",
     "aws-sdk": "^2.282.1",
     "bluebird": "^3.4.0",
     "chalk": "^1.1.1",


### PR DESCRIPTION
Replaces #90
This PR adds pre-deployment definition validation using [asl-validator](https://www.npmjs.com/package/asl-validator). The latter [now supports intrinsic CF functions](https://github.com/airware/asl-validator/pull/35), which removes the need for serverless-pseudo-parameters support.

In contrast to #90 which adds a new command (`sls validate stepf`), here we automatically validate the state machine definitions during the deploy step. The main benefit is to avoid uploading and updating CloudFormation stack in order to detect and fix typos, so it can save some time when developing.

The feature is disabled by default, and can be enabled with a boolean:
```yaml
stepFunctions:
  validate: true
```

I think this behaviour is better than the one in #90, but I'm happy to discuss it and revert it.
AFAIK it's working pretty well, but I haven't tested all the new step functions capabilities and associated services so please open issues/PR [here](https://github.com/airware/asl-validator) if you experience issues.