### PR TITLE
feat: add all authorizer context properties to lambda_proxy template

### DIFF
--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -65,7 +65,9 @@ const LAMBDA_PROXY_REQUEST_TEMPLATE = `
       #set( $map = $context.identity )
       "identity": $loop,
       "domainName": "$context.domainName",
-      "apiId": "$context.apiId"
+      "apiId": "$context.apiId",
+      #set( $map = $context.authorizer )
+      "authorizer": $loop,
     },
     "body": "$util.escapeJavaScript("$body")",
     "isBase64Encoded": false


### PR DESCRIPTION
It seems in the `LAMBDA_PROXY_REQUEST_TEMPLATE`, all the variables `$context.authorizer.*` are omitted.

Looping on the `$context.authorizer.*` allow you to get back the data you pass in a policy generated by a custom authorizer.

Source : https://docs.aws.amazon.com/en_en/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html and https://docs.aws.amazon.com/en_en/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html