### PR TITLE
feat: support EventBusName for custom Cloudwatch event bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,29 @@ stepFunctions:
         ...
 ```
 
+#### Specifying a custom CloudWatch EventBus
+
+You can choose which CloudWatch Event bus to listen to:
+
+```yml
+stepFunctions:
+  stateMachines:
+    cloudwatchEvent:
+      events:
+        - cloudwatchEvent:
+            eventBusName: 'my-custom-event-bus'
+            event:
+              source:
+                - "my.custom.source"
+              detail-type:
+                - "My Event Type"
+              detail:
+                state:
+                  - pending
+      definition:
+        ...
+```
+
 ## Tags
 
 You can specify tags on each state machine. Additionally any global tags (specified under `provider` section in your `serverless.yml`) would be merged in as well.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This is the Serverless Framework plugin for AWS Step Functions.
          - [Specify Input or Inputpath](#specify-input-or-inputpath)
          - [Specifying a Description](#specifying-a-description)
          - [Specifying a Name](#specifying-a-name)
+         - [Specifying a custom CloudWatch EventBus](#specifying-a-custom-cloudwatch-eventbus)
  - [Tags](#tags)
  - [Commands](#commands)
      - [deploy](#deploy)

--- a/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
+++ b/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
@@ -19,6 +19,7 @@ module.exports = {
             let InputPath;
             let Description;
             let Name;
+            let EventBusName;
 
             if (typeof event.cloudwatchEvent === 'object') {
               if (!event.cloudwatchEvent.event) {
@@ -39,6 +40,7 @@ module.exports = {
               InputPath = event.cloudwatchEvent.inputPath;
               Description = event.cloudwatchEvent.description;
               Name = event.cloudwatchEvent.name;
+              EventBusName = event.cloudwatchEvent.eventBusName;
 
               if (Input && InputPath) {
                 const errorMessage = [
@@ -78,6 +80,7 @@ module.exports = {
               {
                 "Type": "AWS::Events::Rule",
                 "Properties": {
+                  ${EventBusName ? `"EventBusName": "${EventBusName}",` : ''}
                   "EventPattern": ${EventPattern.replace(/\\n|\\r/g, '')},
                   "State": "${State}",
                   ${Description ? `"Description": "${Description}",` : ''}

--- a/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.test.js
+++ b/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.test.js
@@ -262,6 +262,36 @@ describe('awsCompileCloudWatchEventEvents', () => {
         .Properties.Name).to.equal('test-event-name');
     });
 
+    it('should respect eventBusName variable', () => {
+      serverlessStepFunctions.serverless.service.stepFunctions = {
+        stateMachines: {
+          first: {
+            events: [
+              {
+                cloudwatchEvent: {
+                  event: {
+                    source: ['aws.ec2'],
+                    'detail-type': ['EC2 Instance State-change Notification'],
+                    detail: { state: ['pending'] },
+                  },
+                  enabled: false,
+                  input: '{"key":"value"}',
+                  name: 'test-event-name',
+                  eventBusName: 'custom-event-bus',
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      serverlessStepFunctions.compileCloudWatchEventEvents();
+
+      expect(serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleCloudWatchEvent1
+        .Properties.EventBusName).to.equal('custom-event-bus');
+    });
+
     it('should respect input variable as an object', () => {
       serverlessStepFunctions.serverless.service.stepFunctions = {
         stateMachines: {


### PR DESCRIPTION
This will add support to custom cloudwatch event buses or EventBridge. 

Two weeks ago, AWS [added support ](https://aws.amazon.com/about-aws/whats-new/2019/10/amazon-eventbridge-supports-aws-cloudformation/?nc1=h_ls)to use custom `EventBusName` in `AWS::Events::Rule` resources : https://docs.aws.amazon.com/en_pv/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-eventbusname