### PR TITLE
support relative config filename

### DIFF
--- a/lib/yamlParser.js
+++ b/lib/yamlParser.js
@@ -11,7 +11,7 @@ module.exports = {
       return BbPromise.resolve();
     }
 
-    const serviceFileName = this.serverless.config.serverless.service.serviceFilename || 'serverless.yml';
+    const serviceFileName = this.options.config || this.serverless.config.serverless.service.serviceFilename || 'serverless.yml';
     const serverlessYmlPath = path.join(servicePath, serviceFileName);
     return this.serverless.yamlParser
       .parse(serverlessYmlPath)

--- a/lib/yamlParser.test.js
+++ b/lib/yamlParser.test.js
@@ -2,6 +2,7 @@
 
 const expect = require('chai').expect;
 const sinon = require('sinon');
+const path = require('path');
 const BbPromise = require('bluebird');
 const Serverless = require('serverless/lib/Serverless');
 const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider');
@@ -152,6 +153,17 @@ describe('#yamlParse', () => {
       serverlessStepFunctions.yamlParse()
         .then(() => {
           expect(yamlParserStub.calledWith(`${servicePath}/${fileName}`)).to.be.equal(true);
+        });
+    });
+
+    it('should read relative serviceFileName path if passed as --config option', () => {
+      const servicePath = serverlessStepFunctions.serverless.config.servicePath;
+      const relativeFilename = './some_folder/other_config.yml';
+      serverlessStepFunctions.options.config = relativeFilename;
+      const serviceFilePath = path.normalize(`${servicePath}/${relativeFilename}`);
+      serverlessStepFunctions.yamlParse()
+        .then(() => {
+          expect(yamlParserStub.calledWith(serviceFilePath)).to.be.equal(true);
         });
     });
   });


### PR DESCRIPTION
The plugin does not currently work if you try to use a custom config file that is in another folder.  This PR attempts to fix that.

```
$ sls deploy --config ./services/myfile.yml
 
  Error --------------------------------------------------
 
  Error: ENOENT: no such file or directory, open '/mypath/myfile.yml'
      at Object.fs.openSync (fs.js:646:18)
      at Object.fs.readFileSync (fs.js:551:33)
      at readFileSync (/Users/me/.nvm/versions/node/v8.12.0/lib/node_modules/serverless/lib/utils/fs/readFileSync.js:7:24)
      at Utils.readFileSync (/Users/me/.nvm/versions/node/v8.12.0/lib/node_modules/serverless/lib/classes/Utils.js:84:12)
      at YamlParser.parse (/Users/me/.nvm/versions/node/v8.12.0/lib/node_modules/serverless/lib/classes/YamlParser.js:17:40)
      at ServerlessStepFunctions.yamlParse (/mypath/node_modules/serverless-step-functions/lib/yamlParser.js:17:8)
      at ServerlessStepFunctions.tryCatcher (/mypath/node_modules/bluebird/js/release/util.js:16:23)
      at Promise._settlePromiseFromHandler (/mypath/node_modules/bluebird/js/release/promise.js:547:31)
      at Promise._settlePromise (/mypath/node_modules/bluebird/js/release/promise.js:604:18)
      at Promise._settlePromiseCtx (/mypath/node_modules/bluebird/js/release/promise.js:641:10)
      at _drainQueueStep (/mypath/node_modules/bluebird/js/release/async.js:97:12)
      at _drainQueue (/mypath/node_modules/bluebird/js/release/async.js:86:9)
      at Async._drainQueues (/mypath/node_modules/bluebird/js/release/async.js:102:5)
      at Immediate.Async.drainQueues (/mypath/node_modules/bluebird/js/release/async.js:15:14)
      at runCallback (timers.js:810:20)
      at tryOnImmediate (timers.js:768:5)
      at processImmediate [as _immediateCallback] (timers.js:745:5)
```
