### PR TITLE
fix invalid lambda_proxy template

### DIFF
--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -65,9 +65,9 @@ const LAMBDA_PROXY_REQUEST_TEMPLATE = `
       #set( $map = $context.identity )
       "identity": $loop,
       "domainName": "$context.domainName",
-      "apiId": "$context.apiId",
       #set( $map = $context.authorizer )
       "authorizer": $loop,
+      "apiId": "$context.apiId"
     },
     "body": "$util.escapeJavaScript("$body")",
     "isBase64Encoded": false


### PR DESCRIPTION
It seems like #254 broke the lambda proxy template by introducing an extra comma at the end of a loop, causing an invalid json structure.
This is a simple fix - moving the loop so it's not the end of the json structure