### PR TITLE
Fix serialization errors in lambda_proxy template when using single quotes in payload

### DIFF
--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -69,12 +69,12 @@ const LAMBDA_PROXY_REQUEST_TEMPLATE = `
       #set( $map = $context.authorizer )
       "authorizer": $loop,
     },
-    "body": "$util.escapeJavaScript("$body")",
+    "body": "$util.escapeJavaScript("$body").replaceAll("\\\\'", "'")",
     "isBase64Encoded": false
   }
   #end
   {
-    "input": "$util.escapeJavaScript("$smInput")",
+    "input": "$util.escapeJavaScript("$smInput").replaceAll("\\\\'", "'")",
     "name":"$context.requestId",
     "stateMachineArn":"\${StateMachineArn}"
   }`;

--- a/lib/deploy/events/apiGateway/methods.test.js
+++ b/lib/deploy/events/apiGateway/methods.test.js
@@ -284,6 +284,20 @@ describe('#methods()', () => {
     });
   });
 
+  describe('#getLambdaProxyRequestTemplates()', () => {
+    it('application/json proxy template should not have escaped single quotes', () => {
+      const lambdaProxyRequestTemplate = serverlessStepFunctions
+        .getLambdaProxyRequestTemplates('stateMachine', undefined);
+
+      // Using negative lookahead, look for escapeJavaScript calls without the
+      // required stripping of escaped single quotes after
+      const escapeJavascriptPattern = /\$util.escapeJavaScript\("\$\w+"\)/;
+      const unescapeSingleQuotesPattern = /\.replaceAll\("\\\\'", *"'"\)/;
+      const regExp = new RegExp(`${escapeJavascriptPattern.source}(?!${unescapeSingleQuotesPattern.source})`);
+      expect(lambdaProxyRequestTemplate['application/json']['Fn::Sub'][0]).not.to.match(regExp);
+    });
+  });
+
   describe('#getMethodResponses()', () => {
     it('should return a corresponding methodResponses resource', () => {
       expect(serverlessStepFunctions.getMethodResponses().Properties)


### PR DESCRIPTION
Applying the single quote fix from #235 to lambda proxy template